### PR TITLE
missing comma in example on validators/format/index

### DIFF
--- a/docs/validators/format/index.html
+++ b/docs/validators/format/index.html
@@ -236,7 +236,7 @@ validator('format', {
   type: 'email'
 })
 validator('format', {
-  allowBlank: true
+  allowBlank: true,
   type: 'phone'
 })
 validator('format', {


### PR DESCRIPTION
Missing comma after allowBlank