### PR TITLE
Add presence-or validator

### DIFF
--- a/app/validators/presence-or.js
+++ b/app/validators/presence-or.js
@@ -1,24 +1,40 @@
 import Ember from 'ember';
 import BaseValidator from 'ember-cp-validations/validators/base';
 
-const { isPresent } = Ember;
+const { isBlank, isEqual, isPresent, typeOf } = Ember;
 
 export default BaseValidator.extend({
-  keysPresent(value, keys, model) {
+  keyPresent(model, key) {
+    const value = key ? model.get(key) : model;
+    if (isBlank(value)) {
+      return false;
+    }
+    // If an object is present, it may be an empty `PromiseObject` or `PromiseArray` from an Ember-Data relationship
+    const constructor = value.constructor;
+    if (isEqual(typeOf(value.get), 'function') && isPresent(constructor) && isEqual(typeOf(constructor.toString), 'function')) {
+      const type = constructor.toString();
+      if (['DS.PromiseObject', 'DS.PromiseArray'].indexOf(type) !== -1) {
+        return isPresent(value.get('content'));
+      }
+    }
+    return true;
+  },
+
+  _keysPresent(value, keys, model) {
     let presentCount = 0;
     for (let i = 0; i < keys.length; i++) { // for-of loops fail in phantomJS, falling back to regular for-loop
-      if (isPresent(model.get(keys[i]))) {
+      if (this.keyPresent(model, keys[i])) {
         presentCount++;
       }
     }
-    if (isPresent(value)) {
+    if (this.keyPresent(value)) {
       presentCount++;
     }
     return presentCount;
   },
 
-  isPresent(value, options, model) {
-    const keysPresent = this.keysPresent(value, options.dependentKeys || [], model);
+  keysPresent(value, options, model) {
+    const keysPresent = this._keysPresent(value, options.dependentKeys || [], model);
     return !(!keysPresent || (options.exclusive && keysPresent > 1));
   },
 
@@ -47,7 +63,7 @@ export default BaseValidator.extend({
   },
 
   validate(value, options, model) {
-    const present = this.isPresent(value, options, model);
+    const present = this.keysPresent(value, options, model);
     options.message = options.message || this.defaultMessage;
 
     if ((options.presence === true || options.presence === undefined) && !present) {

--- a/app/validators/presence-or.js
+++ b/app/validators/presence-or.js
@@ -1,0 +1,64 @@
+import Ember from 'ember';
+import BaseValidator from 'ember-cp-validations/validators/base';
+
+const { isPresent } = Ember;
+
+export default BaseValidator.extend({
+  keysPresent(value, keys, model) {
+    let presentCount = 0;
+    for (let i = 0; i < keys.length; i++) { // for-of loops fail in phantomJS, falling back to regular for-loop
+      if (isPresent(model.get(keys[i]))) {
+        presentCount++;
+      }
+    }
+    if (isPresent(value)) {
+      presentCount++;
+    }
+    return presentCount;
+  },
+
+  isPresent(value, options, model) {
+    const keysPresent = this.keysPresent(value, options.dependentKeys || [], model);
+    return !(!keysPresent || (options.exclusive && keysPresent > 1));
+  },
+
+  defaultMessage(type, value, options) {
+    let attributeList = this.get('attribute');
+    const keys = options.dependentKeys;
+    if (Ember.isPresent(keys)) {
+      attributeList = `${attributeList}, ${keys.join(', ')}`;
+    }
+    let prefix;
+    if (!options.exclusive) {
+      if (Ember.isEqual(type, 'present')) {
+        prefix = 'At least one';
+      } else {
+        prefix = 'All';
+      }
+    } else {
+      if (Ember.isEqual(type, 'present')) {
+        prefix = 'Exactly one';
+      } else {
+        prefix = 'More than one or none';
+        type = 'present';
+      }
+    }
+    return `${prefix} of these attributes must be ${type}: ${attributeList}`;
+  },
+
+  validate(value, options, model) {
+    const present = this.isPresent(value, options, model);
+    options.message = options.message || this.defaultMessage;
+
+    if ((options.presence === true || options.presence === undefined) && !present) {
+      return this.createErrorMessage('present', value, options);
+    }
+
+    if (options.presence === false && present) {
+      return this.createErrorMessage('blank', value, options);
+    }
+
+    return true;
+  }
+});
+

--- a/tests/unit/validators/presence-or-test.js
+++ b/tests/unit/validators/presence-or-test.js
@@ -29,6 +29,46 @@ test('presence - values not present', function(assert) {
   assert.equal(message, `At least one of these attributes must be present: ${validator.get('attribute')}, ${key}`);
 });
 
+test('presence - values not present - belongsTo', function(assert) {
+  assert.expect(1);
+  const promiseObject = {
+    get() {
+      return null;
+    },
+
+    constructor: {
+      toString() {
+        return 'DS.PromiseObject';
+      }
+    }
+  };
+
+  model.set(key, promiseObject);
+  const options = { presence: true, dependentKeys: [key] };
+  const message = validator.validate(undefined, options, model);
+  assert.equal(message, `At least one of these attributes must be present: ${validator.get('attribute')}, ${key}`);
+});
+
+test('presence - values not present - hasMany', function(assert) {
+  assert.expect(1);
+  const promiseArray = {
+    get() {
+      return [];
+    },
+
+    constructor: {
+      toString() {
+        return 'DS.PromiseArray';
+      }
+    }
+  };
+
+  model.set(key, promiseArray);
+  const options = { presence: true, dependentKeys: [key] };
+  const message = validator.validate(undefined, options, model);
+  assert.equal(message, `At least one of these attributes must be present: ${validator.get('attribute')}, ${key}`);
+});
+
 test('presence undefined - values present', function(assert) {
   assert.expect(1);
 

--- a/tests/unit/validators/presence-or-test.js
+++ b/tests/unit/validators/presence-or-test.js
@@ -1,0 +1,139 @@
+import Ember from 'ember';
+import { moduleFor, test } from 'ember-qunit';
+
+let validator, model, key;
+
+moduleFor('validator:presence-or', 'Unit | Validator | presence-or', {
+  needs: ['validator:messages'],
+  setup: function() {
+    key = 'foo';
+    model = Ember.Object.create({ [key]: 'bar' });
+    validator = this.subject({ attribute: 'stuff' });
+  }
+});
+
+test('presence - values present', function(assert) {
+  assert.expect(1);
+
+  const options = { presence: true, dependentKeys: [key] };
+  const message = validator.validate('value', options, model);
+  assert.equal(message, true);
+});
+
+test('presence - values not present', function(assert) {
+  assert.expect(1);
+
+  model.set(key, undefined);
+  const options = { presence: true, dependentKeys: [key] };
+  const message = validator.validate(undefined, options, model);
+  assert.equal(message, `At least one of these attributes must be present: ${validator.get('attribute')}, ${key}`);
+});
+
+test('presence undefined - values present', function(assert) {
+  assert.expect(1);
+
+  const options = { dependentKeys: [key] };
+  const message = validator.validate('value', options, model);
+  assert.equal(message, true);
+});
+
+test('presence undefined - values not present', function(assert) {
+  assert.expect(1);
+
+  model.set(key, undefined);
+  const options = { dependentKeys: [key] };
+  const message = validator.validate(undefined, options, model);
+  assert.equal(message, `At least one of these attributes must be present: ${validator.get('attribute')}, ${key}`);
+});
+
+test('absence - values present', function(assert) {
+  assert.expect(1);
+
+  const options = { presence: false, dependentKeys: [key] };
+  const message = validator.validate('value', options, model);
+  assert.equal(message, `All of these attributes must be blank: ${validator.get('attribute')}, ${key}`);
+});
+
+test('absence - values not present', function(assert) {
+  assert.expect(1);
+
+  model.set(key, undefined);
+  const options = { presence: false, dependentKeys: [key] };
+  const message = validator.validate(undefined, options, model);
+  assert.equal(message, true);
+});
+
+test('exclusive presence - values present', function(assert) {
+  assert.expect(1);
+
+  const options = { presence: true, dependentKeys: [key], exclusive: true };
+  const message = validator.validate('value', options, model);
+  assert.equal(message, `Exactly one of these attributes must be present: ${validator.get('attribute')}, ${key}`);
+});
+
+test('exclusive presence - one value present', function(assert) {
+  assert.expect(1);
+
+  const options = { presence: true, dependentKeys: [key], exclusive: true };
+  const message = validator.validate(undefined, options, model);
+  assert.equal(message, true);
+});
+
+test('exclusive presence - values not present', function(assert) {
+  assert.expect(1);
+
+  model.set(key, undefined);
+  const options = { presence: true, dependentKeys: [key], exclusive: true };
+  const message = validator.validate(undefined, options, model);
+  assert.equal(message, `Exactly one of these attributes must be present: ${validator.get('attribute')}, ${key}`);
+});
+
+test('exclusive presence undefined - values present', function(assert) {
+  assert.expect(1);
+
+  const options = { dependentKeys: [key], exclusive: true };
+  const message = validator.validate('value', options, model);
+  assert.equal(message, `Exactly one of these attributes must be present: ${validator.get('attribute')}, ${key}`);
+});
+
+test('exclusive presence undefined - one value present', function(assert) {
+  assert.expect(1);
+
+  const options = { dependentKeys: [key], exclusive: true };
+  const message = validator.validate(undefined, options, model);
+  assert.equal(message, true);
+});
+
+test('exclusive presence undefined - values not present', function(assert) {
+  assert.expect(1);
+
+  model.set(key, undefined);
+  const options = { dependentKeys: [key], exclusive: true };
+  const message = validator.validate(undefined, options, model);
+  assert.equal(message, `Exactly one of these attributes must be present: ${validator.get('attribute')}, ${key}`);
+});
+
+test('exclusive absence - values present', function(assert) {
+  assert.expect(1);
+
+  const options = { presence: false, dependentKeys: [key], exclusive: true };
+  const message = validator.validate('value', options, model);
+  assert.equal(message, true);
+});
+
+test('exclusive absence - one value present', function(assert) {
+  assert.expect(1);
+
+  const options = { presence: false, dependentKeys: [key], exclusive: true };
+  const message = validator.validate(undefined, options, model);
+  assert.equal(message, `More than one or none of these attributes must be present: ${validator.get('attribute')}, ${key}`);
+});
+
+test('exclusive absence - values not present', function(assert) {
+  assert.expect(1);
+
+  model.set(key, undefined);
+  const options = { presence: false, dependentKeys: [key], exclusive: true };
+  const message = validator.validate(undefined, options, model);
+  assert.equal(message, true);
+});

--- a/tests/unit/validators/presence-test.js
+++ b/tests/unit/validators/presence-test.js
@@ -4,13 +4,9 @@
  */
 
 import Ember from 'ember';
-import {
-  moduleFor, test
-}
-from 'ember-qunit';
+import { moduleFor, test } from 'ember-qunit';
 
-var options, validator, message;
-var set = Ember.set;
+let validator;
 
 moduleFor('validator:presence', 'Unit | Validator | presence', {
   needs: ['validator:messages'],
@@ -22,7 +18,7 @@ moduleFor('validator:presence', 'Unit | Validator | presence', {
 test('buildOptions', function(assert) {
   assert.expect(2);
 
-  options = true;
+  let options = true;
   let builtOptions = validator.buildOptions(options, {});
   assert.deepEqual(builtOptions, { presence: true });
 
@@ -34,16 +30,16 @@ test('buildOptions', function(assert) {
 test('presence - value present', function(assert) {
   assert.expect(1);
 
-  options = { presence: true };
-  message = validator.validate('value', options);
+  const options = { presence: true };
+  const message = validator.validate('value', options);
   assert.equal(message, true);
 });
 
 test('presence - value not present', function(assert) {
   assert.expect(1);
 
-  options = { presence: true };
-  message = validator.validate(undefined, options);
+  const options = { presence: true };
+  const message = validator.validate(undefined, options);
   assert.equal(message, "This field can't be blank");
 });
 
@@ -51,16 +47,15 @@ test('presence - value not present', function(assert) {
 test('absence - value present', function(assert) {
   assert.expect(1);
 
-  options = { presence: false };
-  message = validator.validate('value', options);
+  const options = { presence: false };
+  const message = validator.validate('value', options);
   assert.equal(message, "This field must be blank");
 });
 
 test('absence - value not present', function(assert) {
   assert.expect(1);
 
-  options = { presence: false };
-
-  message = validator.validate(undefined, options);
+  const options = { presence: false };
+  const message = validator.validate(undefined, options);
   assert.equal(message, true);
 });


### PR DESCRIPTION
This validator checks for the presence of one or more values based on the attribute tied to the validator and the `dependentKeys` array passed into `options`.

Users can also pass an `exclusive: true` option that makes this an exclusive-or check. That is, it expects the presence of one and only one of the values being watched.