### PR TITLE
Makes isDirty work properly for boolean

### DIFF
--- a/addon/validations/result.js
+++ b/addon/validations/result.js
@@ -64,7 +64,7 @@ var ValidationsObject = Ember.Object.extend({
       let attrMeta = model.get('constructor.attributes').get(attribute);
       if (attrMeta) {
         let defaultValue = attrMeta.options.defaultValue;
-        if (defaultValue) {
+        if (!isNone(defaultValue)) {
           return defaultValue !== attrValue;
         }
       }

--- a/tests/dummy/app/models/signup.js
+++ b/tests/dummy/app/models/signup.js
@@ -1,0 +1,19 @@
+import DS from 'ember-data';
+import {
+  validator, buildValidations
+}
+from 'ember-cp-validations';
+
+
+let Validations = buildValidations({
+  name: validator('presence', true),
+  acceptTerms: validator((value) => {
+    return value || 'You must accept the terms.';
+  }),
+});
+
+
+export default DS.Model.extend(Validations, {
+  name: DS.attr('string', { defaultValue: '' }),
+  acceptTerms: DS.attr('boolean', { defaultValue: false }),
+});

--- a/tests/unit/validations/ds-model-test.js
+++ b/tests/unit/validations/ds-model-test.js
@@ -1,0 +1,34 @@
+import Ember from 'ember';
+import {
+  moduleForModel,
+  test
+}
+from 'ember-qunit';
+
+moduleForModel('signup', 'Unit | Validations | DS.Model', {
+
+});
+
+test('create model with defaults', function(assert) {
+  var object = this.subject();
+
+  assert.equal(object.get('validations.attrs.acceptTerms.isDirty'), false, 'isDirty was expected to be FALSE');
+  assert.equal(object.get('validations.attrs.acceptTerms.isValid'), false, 'isValid was expected to be FALSE');
+
+  Ember.run(() => { object.set('acceptTerms', true); });
+
+  assert.equal(object.get('validations.attrs.acceptTerms.isDirty'), true, 'isDirty was expected to be TRUE');
+  assert.equal(object.get('validations.attrs.acceptTerms.isValid'), true, 'isValid was expected to be TRUE');
+});
+
+test('create model overriding defaults', function(assert) {
+  var object = this.subject({acceptTerms: true});
+
+  assert.equal(object.get('validations.attrs.acceptTerms.isDirty'), true, 'isDirty was expected to be TRUE');
+  assert.equal(object.get('validations.attrs.acceptTerms.isValid'), true, 'isValid was expected to be TRUE');
+
+  Ember.run(() => { object.set('acceptTerms', false); });
+
+  assert.equal(object.get('validations.attrs.acceptTerms.isDirty'), false, 'isDirty was expected to be FALSE');
+  assert.equal(object.get('validations.attrs.acceptTerms.isValid'), false, 'isValid was expected to be FALSE');
+});


### PR DESCRIPTION
For boolean attributes with defaultValue === false, isDirty always returned true. This should fix that. All tests pass.