### PR TITLE
Clear errors implementation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,8 @@ env:
   - EMBER_TRY_SCENARIO=ember-1.11
   - EMBER_TRY_SCENARIO=ember-1.12
   - EMBER_TRY_SCENARIO=ember-1.13
+  - EMBER_TRY_SCENARIO=ember-2.0
+  - EMBER_TRY_SCENARIO=ember-2.1
   - EMBER_TRY_SCENARIO=ember-release
   - EMBER_TRY_SCENARIO=ember-beta
   - EMBER_TRY_SCENARIO=ember-canary

--- a/addon/validations/result-collection.js
+++ b/addon/validations/result-collection.js
@@ -13,6 +13,7 @@ const {
   RSVP,
   computed,
   isEmpty,
+  makeArray,
   A: emberArray
 } = Ember;
 
@@ -87,5 +88,27 @@ export default Ember.Object.extend({
     var isAsync = get(this, 'isAsync');
     var promise = get(this, '_promise');
     return isAsync ? promise : this;
-  }))
+  })),
+
+  /**
+   * Clear all errors in this result collection
+   * A single type or multiple validator types can be specified. (i.e. clearErrors('presence') or clearErrors(['presence', 'length']))
+   * @param  {String/Array} types
+   * @return
+   */
+  clearErrors(types) {
+    let content = get(this, 'content');
+    types = makeArray(types);
+
+    if (!isEmpty(types)) {
+      content = content.filter(result => types.indexOf(get(result, '_type')) !== -1);
+    }
+
+    content.forEach(result => {
+      result.update({
+        message: null,
+        isValid: true
+      });
+    });
+  }
 });

--- a/addon/validations/result.js
+++ b/addon/validations/result.js
@@ -33,7 +33,8 @@ var ValidationsObject = Ember.Object.extend({
   isValid: true,
   isValidating: false,
   message: null,
-  attribute: '',
+  attribute: null,
+  _type: null,
 
   attrValue: undefined,
   _promise: undefined,
@@ -94,7 +95,8 @@ var ValidationsObject = Ember.Object.extend({
 
 export default Ember.Object.extend({
   model: null,
-  attribute: '',
+  attribute: null,
+  _type: null,
   _promise: undefined,
 
   isValid: computed.oneWay('_validations.isValid'),
@@ -110,7 +112,7 @@ export default Ember.Object.extend({
 
   // This hold all the logic for the above CPs. We do this so we can easily switch this object out with a different validations object
   _validations: computed('model', 'attribute', '_promise', function() {
-    return ValidationsObject.create(getProperties(this, ['model', 'attribute', '_promise']));
+    return ValidationsObject.create(getProperties(this, ['model', 'attribute', '_promise', '_type']));
   }),
 
   init() {

--- a/config/ember-try.js
+++ b/config/ember-try.js
@@ -26,6 +26,18 @@ module.exports = {
       'ember-data': '~1.13.0'
     }
   }, {
+    name: 'ember-2.0',
+    dependencies: {
+      ember: '~2.0.0',
+      'ember-data': '~2.0.0'
+    }
+  }, {
+    name: 'ember-2.1',
+    dependencies: {
+      ember: '~2.1.0',
+      'ember-data': '~2.1.0'
+    }
+  }, {
     name: 'ember-1.13',
     dependencies: {
       ember: '~1.13.0',

--- a/package.json
+++ b/package.json
@@ -27,6 +27,10 @@
     {
       "name": "Ben Limmer",
       "email": "hello@benlimmer.com"
+    },
+    {
+      "name": "Robert Jackson",
+      "email": "me@rwjblue.com"
     }
   ],
   "license": "BSD-3-Clause",

--- a/tests/integration/validations/factory-general-test.js
+++ b/tests/integration/validations/factory-general-test.js
@@ -1,25 +1,23 @@
 import Ember from 'ember';
 import setupObject from '../../helpers/setup-object';
+import DefaultMessages from 'dummy/validators/messages';
+import LengthValidator from 'dummy/validators/length';
+import PresenceValidator from 'dummy/validators/presence';
 import { validator, buildValidations } from 'ember-cp-validations';
 import { moduleFor, test } from 'ember-qunit';
 
-var Validators = {
-  presence(value, options, model, attr) {
-    var isValid = !Ember.isNone(value);
-    if (Ember.isNone(value)) {
-      return `${attr} should be present`;
-    }
-    return true;
-  }
-};
-
 var Validations = buildValidations({
-  firstName: validator(Validators.presence),
-  lastName: validator(Validators.presence)
+  firstName: validator('presence', true),
+  lastName: validator('presence', true)
 });
 
 moduleFor('foo', 'Integration | Validations | Factory - General', {
   integration: true,
+  beforeEach() {
+    this.register('validator:messages', DefaultMessages);
+    this.register('validator:presence', PresenceValidator);
+    this.register('validator:length', LengthValidator);
+  }
 });
 
 test("it works", function(assert) {
@@ -35,11 +33,11 @@ test("basic sync validation – invalid", function(assert) {
 
   assert.equal(object.get('validations.attrs.firstName.isValid'), false);
   assert.equal(object.get('validations.attrs.firstName.isValidating'), false);
-  assert.equal(object.get('validations.attrs.firstName.message'), 'firstName should be present');
+  assert.equal(object.get('validations.attrs.firstName.message'), "This field can't be blank");
 
   assert.equal(object.get('validations.attrs.lastName.isValid'), false);
   assert.equal(object.get('validations.attrs.lastName.isValidating'), false);
-  assert.equal(object.get('validations.attrs.lastName.message'), 'lastName should be present');
+  assert.equal(object.get('validations.attrs.lastName.message'), "This field can't be blank");
 
   assert.equal(object.get('validations.errors.length'), 2, 'errors length was expected to be 2');
   assert.ok(object.get('validations.errors').indexOf(object.get('validations.attrs.firstName.errors.0')) > -1, 'errors was expected to contain firstName error');
@@ -99,7 +97,7 @@ test("basic sync validation - 50% invalid", function(assert) {
 
   assert.equal(object.get('validations.attrs.lastName.isValid'), false);
   assert.equal(object.get('validations.attrs.lastName.isValidating'), false);
-  assert.equal(object.get('validations.attrs.lastName.message'), 'lastName should be present');
+  assert.equal(object.get('validations.attrs.lastName.message'), "This field can't be blank");
 });
 
 test("basic sync validation - API - #validation", function(assert) {
@@ -122,7 +120,7 @@ test("basic sync validation - API - #validation", function(assert) {
 
     assert.equal(lastName.get('isValid'), false);
     assert.equal(lastName.get('isValidating'), false);
-    assert.equal(lastName.get('message'), 'lastName should be present');
+    assert.equal(lastName.get('message'), "This field can't be blank");
 
     assert.equal(object.get('validations.isValid'), false, 'isValid was expected to be FALSE');
     assert.equal(object.get('validations.isValidating'), false, 'isValidating was expected to be FALSE');
@@ -134,7 +132,7 @@ test("basic sync validation - API - #validation", function(assert) {
 
     assert.equal(object.get('validations.attrs.lastName.isValid'), false);
     assert.equal(object.get('validations.attrs.lastName.isValidating'), false);
-    assert.equal(object.get('validations.attrs.lastName.message'), 'lastName should be present');
+    assert.equal(object.get('validations.attrs.lastName.message'), "This field can't be blank");
   });
 });
 
@@ -160,7 +158,7 @@ test("basic sync validation - API - #validationSync", function(assert) {
 
   assert.equal(lastName.get('isValid'), false);
   assert.equal(lastName.get('isValidating'), false);
-  assert.equal(lastName.get('message'), 'lastName should be present');
+  assert.equal(lastName.get('message'), "This field can't be blank");
 
   assert.equal(object.get('validations.isValid'), false, 'isValid was expected to be FALSE');
   assert.equal(object.get('validations.isValidating'), false, 'isValidating was expected to be FALSE');
@@ -172,7 +170,7 @@ test("basic sync validation - API - #validationSync", function(assert) {
 
   assert.equal(object.get('validations.attrs.lastName.isValid'), false);
   assert.equal(object.get('validations.attrs.lastName.isValidating'), false);
-  assert.equal(object.get('validations.attrs.lastName.message'), 'lastName should be present');
+  assert.equal(object.get('validations.attrs.lastName.message'), "This field can't be blank");
 });
 
 test("basic sync validation returns null", function(assert) {
@@ -219,7 +217,7 @@ test("default options", function(assert) {
     firstName: {
       description: 'Test field',
       validators: [
-        validator(Validators.presence),
+        validator('presence', true),
         validator(() => false)
       ]
     }
@@ -230,4 +228,88 @@ test("default options", function(assert) {
   var rules = Ember.A(object.get('validations._validationRules.firstName'));
   assert.equal(rules.isAny('defaultOptions', undefined), false);
   assert.equal(rules[0].defaultOptions.description, 'Test field');
+});
+
+test("clear errors - all", function(assert) {
+  var object = setupObject(this, Ember.Object.extend(Validations));
+
+  assert.equal(object.get('validations.isValid'), false);
+  assert.equal(object.get('validations.isValidating'), false);
+  assert.equal(object.get('validations.isTruelyValid'), false);
+
+  object.clearErrors();
+
+  assert.equal(object.get('validations.isValid'), true);
+  assert.equal(object.get('validations.isValidating'), false);
+  assert.equal(object.get('validations.isTruelyValid'), true);
+});
+
+test("clear errors - single attribute", function(assert) {
+  var object = setupObject(this, Ember.Object.extend(Validations), {
+    firstName: 'Offir'
+  });
+
+  assert.equal(object.get('validations.isValid'), false);
+  assert.equal(object.get('validations.isValidating'), false);
+  assert.equal(object.get('validations.isTruelyValid'), false);
+
+  assert.equal(object.get('validations.attrs.lastName.isValid'), false);
+  assert.equal(object.get('validations.attrs.lastName.isValidating'), false);
+  assert.equal(object.get('validations.attrs.lastName.message'), "This field can't be blank");
+
+  object.get('validations.attrs.lastName').clearErrors();
+
+  assert.equal(object.get('validations.isValid'), true);
+  assert.equal(object.get('validations.isValidating'), false);
+  assert.equal(object.get('validations.isTruelyValid'), true);
+
+  assert.equal(object.get('validations.attrs.lastName.isValid'), true);
+  assert.equal(object.get('validations.attrs.lastName.isValidating'), false);
+  assert.equal(object.get('validations.attrs.lastName.message'), null);
+});
+
+test("clear errors - single type", function(assert) {
+  var Validations = buildValidations({
+    firstName: [validator('presence', true), validator('length', {min: 7})],
+    lastName: [validator('presence', true), validator('length', {min: 7})],
+  });
+
+  var object = setupObject(this, Ember.Object.extend(Validations), {
+    firstName: 'Offir'
+  });
+
+  assert.equal(object.get('validations.isValid'), false);
+  assert.equal(object.get('validations.isValidating'), false);
+  assert.equal(object.get('validations.isTruelyValid'), false);
+  assert.equal(object.get('validations.messages.length'), 2);
+
+  object.clearErrors('presence');
+
+  assert.equal(object.get('validations.isValid'), false);
+  assert.equal(object.get('validations.isValidating'), false);
+  assert.equal(object.get('validations.isTruelyValid'), false);
+  assert.equal(object.get('validations.messages.length'), 1);
+});
+
+test("clear errors - multiple types", function(assert) {
+  var Validations = buildValidations({
+    firstName: [validator('presence', true), validator('length', {min: 7})],
+    lastName: [validator('presence', true), validator('length', {min: 7})],
+  });
+
+  var object = setupObject(this, Ember.Object.extend(Validations), {
+    firstName: 'Offir'
+  });
+
+  assert.equal(object.get('validations.isValid'), false);
+  assert.equal(object.get('validations.isValidating'), false);
+  assert.equal(object.get('validations.isTruelyValid'), false);
+  assert.equal(object.get('validations.messages.length'), 2);
+
+  object.clearErrors(['presence', 'length']);
+
+  assert.equal(object.get('validations.isValid'), true);
+  assert.equal(object.get('validations.isValidating'), false);
+  assert.equal(object.get('validations.isTruelyValid'), true);
+  assert.equal(object.get('validations.messages.length'), 0);
 });

--- a/tests/integration/validations/model-relationships-test.js
+++ b/tests/integration/validations/model-relationships-test.js
@@ -8,25 +8,16 @@ import PresenceValidator from 'dummy/validators/presence';
 import { validator, buildValidations } from 'ember-cp-validations';
 import { moduleFor, test } from 'ember-qunit';
 
-var Validators = {
-  presence(value, options, model, attr) {
-    var isValid = !Ember.isNone(value);
-    if (Ember.isNone(value)) {
-      return `${attr} should be present`;
-    }
-    return true;
-  }
-};
-
 var Validations = buildValidations({
-  firstName: validator(Validators.presence),
-  lastName: validator(Validators.presence)
+  firstName: validator('presence', true),
+  lastName: validator('presence', true)
 });
 
 moduleFor('foo', 'Integration | Validations | Model Relationships', {
   integration: true,
   beforeEach() {
     this.register('validator:messages', DefaultMessages);
+    this.register('validator:presence', PresenceValidator);
   }
 });
 
@@ -57,7 +48,7 @@ test("belong to validation - no cycle", function(assert) {
 
   assert.equal(friend.get('isValid'), false);
   assert.equal(friend.get('isValidating'), false);
-  assert.equal(friend.get('message'), 'lastName should be present');
+  assert.equal(friend.get('message'), "This field can't be blank");
 
 });
 
@@ -117,7 +108,7 @@ test("has-many relationship is async", function(assert) {
     let friends = validations.get('content').findBy('attribute', 'friends');
 
     assert.equal(friends.get('isValid'), false);
-    assert.equal(friends.get('message'), 'lastName should be present');
+    assert.equal(friends.get('message'), "This field can't be blank");
   });
 
   return validations;
@@ -153,7 +144,7 @@ test("belongs-to relationship is async", function(assert) {
     let friend = validations.get('content').findBy('attribute', 'friend');
 
     assert.equal(friend.get('isValid'), false);
-    assert.equal(friend.get('message'), "lastName should be present");
+    assert.equal(friend.get('message'), "This field can't be blank");
   });
 
   return validations;


### PR DESCRIPTION
Solves #81 

I do have a couple comments/concerns: 

1. Is clearErrors the correct naming for this?
2. When we clear an error message, should the result object be set to `isValid: true`? Or should we just clear the message?
3. Instead of updating the result object, maybe removing it all together from the result collection would make more sense?

Usage:

```js
obj.clearErrors();
obj.clearErrors('presence');
obj.clearErrors(['presence', 'length']);

obj.get('validations.attrs.foo').clearErrors();
// ....