### PR TITLE
validation result options hash

### DIFF
--- a/addon/validations/factory.js
+++ b/addon/validations/factory.js
@@ -253,7 +253,7 @@ function createCPValidationFor(attribute, validations) {
         value = validator.validate(attrValue, options, model, attribute);
       }
 
-      return validationReturnValueHandler(attribute, value, model);
+      return validationReturnValueHandler(attribute, value, model, validator);
     });
 
     return ValidationResultCollection.create({
@@ -314,17 +314,19 @@ function getCPDependentKeysFor(attribute, validations) {
  * @param  {Object} model
  * @return {ValidationResult}
  */
-function validationReturnValueHandler(attribute, value, model) {
+function validationReturnValueHandler(attribute, value, model, validator) {
   var result, _promise;
 
   if (canInvoke(value, 'then')) {
     _promise = Promise.resolve(value);
     result = ValidationResult.create({
-      attribute, _promise, model
+      attribute, _promise, model,
+      _validator: validator
     });
   } else {
     result = ValidationResult.create({
-      attribute, model
+      attribute, model,
+      _validator: validator
     });
     result.update(value);
   }

--- a/addon/validations/result-collection.js
+++ b/addon/validations/result-collection.js
@@ -250,7 +250,7 @@ export default Ember.Object.extend({
    * {
    *   'presence': { presence: true},
    *   'length': { max: 15 },
-   *   'function': [{ regex: /foo/ }, { regex: /bar/ }]
+   *   'regex': [{ regex: /foo/ }, { regex: /bar/ }]
    * }
    * ```
    *

--- a/addon/validations/result-collection.js
+++ b/addon/validations/result-collection.js
@@ -13,6 +13,8 @@ const {
   RSVP,
   computed,
   isEmpty,
+  isArray,
+  isNone,
   A: emberArray
 } = Ember;
 
@@ -225,13 +227,49 @@ export default Ember.Object.extend({
   })),
 
   /**
+   * All built options of the validators associated with the results in this collection grouped by validator type
+   *
+   * ```javascript
+   * // Given the following validators
+   * {
+   *   username: [
+   *     validator('presence', true),
+   *     validator('length', { max: 15 }),
+   *     validator('format', { regex: /foo/ }),
+   *     validator('format', { regex: /bar/ }),
+   *   ]
+   * }
+   * ```
+   *
+   * ```js
+   * get(user, 'validations.attrs.username.options')
+   * ```
+   *
+   * The above will return the following
+   * ```js
+   * {
+   *   'presence': { presence: true},
+   *   'length': { max: 15 },
+   *   'function': [{ regex: /foo/ }, { regex: /bar/ }]
+   * }
+   * ```
+   *
+   * @property options
+   * @readOnly
+   * @type {Ember.ComputedProperty | Object}
+   */
+  options: computed('content.[]', function() {
+    return this._groupValidatorOptions();
+  }),
+
+  /**
    * @property _promise
    * @async
    * @private
    * @type {Ember.ComputedProperty | Promise}
    */
   _promise: computed('content.@each._promise', cycleBreaker(function() {
-    var promises = get(this, 'content').getEach('_promise');
+    let promises = get(this, 'content').getEach('_promise');
     if (!isEmpty(promises)) {
       return RSVP.all(compact(flatten(promises)));
     }
@@ -239,12 +277,41 @@ export default Ember.Object.extend({
 
   /**
    * @property value
-   * @private
    * @type {Ember.ComputedProperty}
+   * @private
    */
   value: computed('isAsync', cycleBreaker(function() {
-    var isAsync = get(this, 'isAsync');
-    var promise = get(this, '_promise');
-    return isAsync ? promise : this;
-  }))
+    return get(this, 'isAsync') ? get(this, '_promise') : this;
+  })),
+
+  /**
+   * Used by the `options` property to create a hash from the `content` that is grouped by validator type.
+   * If there is more than 1 of a type, it groups it into an array of option objects.
+   *
+   * @method  _groupValidatorOptions
+   * @return  {Object}
+   * @private
+   */
+  _groupValidatorOptions() {
+    let validators = get(this, 'content').getEach('_validator');
+    return validators.reduce((options, v) => {
+      if(isNone(v) || isNone(get(v, '_type'))) {
+        return options;
+      }
+
+      let type = get(v, '_type');
+      let vOpts = get(v, 'options');
+
+      if(options[type]) {
+        if(isArray(options[type])) {
+          options[type].push(vOpts);
+        } else {
+          options[type] = [options[type], vOpts];
+        }
+      } else {
+        options[type] = vOpts;
+      }
+      return options;
+    }, {});
+  }
 });

--- a/addon/validations/result.js
+++ b/addon/validations/result.js
@@ -120,6 +120,14 @@ export default Ember.Object.extend({
   _promise: undefined,
 
   /**
+   * The validator that returned this result
+   * @property _validator
+   * @private
+   * @type {Validator}
+   */
+  _validator: null,
+
+  /**
    * @property isValid
    * @readOnly
    * @type {Ember.ComputedProperty}

--- a/addon/validations/validator.js
+++ b/addon/validations/validator.js
@@ -88,10 +88,25 @@ const {
  * The return value must be a `string`. If nothing is returned (`undefined`), defaults to the default error message of the specified type.
  *
  * Within this function, the context is set to that of the current validator. This gives you access to the model, defaultMessages, options and more.
-
+ *
+ *
+ * ## Function Based Validators
+ *
+ * A validator can also be declared with a function. The function will be then wrapped in the [Base Validator](./base.md) class and used just like any other pre-defined validator.
+ *
+ * ```javascript
+ * // Example
+ * validator(function(value, options, model, attribute) {
+ *   return value === options.username ? true : `must be ${options.username}`;
+ * } , {
+ *     username: 'John' // Any options can be passed here
+ * })
+ * ```
+ *
  * @module Validators
  * @main Validators
  */
+
 export default function(arg1, options) {
   options = isNone(options) ? {} : options;
 


### PR DESCRIPTION
Should resolve #93 

All built options of the validators associated with the results in this collection grouped by validator type

```javascript
// Given the following validators
{
  username: [
    validator('presence', true),
    validator('length', { max: 15 }),
    validator('format', { regex: /foo/ }),
    validator('format', { regex: /bar/ }),
  ]
}
```

```js
get(user, 'validations.attrs.username.options')
```

The above will return the following
```js
{
  'presence': { presence: true},
  'length': { max: 15 },
  'regex': [{ regex: /foo/ }, { regex: /bar/ }]
}
```

This will also allow you to do the following: 

```hbs
{{input value=model.username
        required=model.validations.attrs.username.options.presence
        maxlength=model.validations.attrs.username.options.length.max}}
```