### PR TITLE
Reprocess options after debounce

### DIFF
--- a/addon/validations/factory.js
+++ b/addon/validations/factory.js
@@ -247,7 +247,7 @@ function createCPValidationFor(attribute, validations) {
         let cache = getDebouncedValidationsCacheFor(attribute, model);
         // Return a promise and pass the resolve method to the debounce handler
         value = new Promise(resolve => {
-          cache[getKey(validator)] = run.debounce(validator, () => resolve(validator.validate(attrValue, options, model, attribute)), debounce, false);
+          cache[getKey(validator)] = run.debounce(validator, () => resolve(validator.validate(attrValue, validator.processOptions(), model, attribute)), debounce, false);
         });
       } else {
         value = validator.validate(attrValue, options, model, attribute);


### PR DESCRIPTION
There could be times where function based options are time sensitive and need to be computed right before we call validate. Unfortunately this means having to call `processOptions` twice. 