### PR TITLE
Expose disabled validator option

### DIFF
--- a/addon/index.js
+++ b/addon/index.js
@@ -42,7 +42,7 @@ export var validator = Validator;
  * }
  * from 'ember-cp-validations';
  *
- * var Validations = buildValidations({
+ * const Validations = buildValidations({
  *   username: validator('presence', true),
  *   password: [
  *     validator('presence', true),
@@ -91,7 +91,7 @@ export var validator = Validator;
  * }
  * from 'ember-cp-validations';
  *
- * var Validations = buildValidations({
+ * const Validations = buildValidations({
  *   bar: validator('presence', true)
  * });
  *
@@ -154,7 +154,7 @@ export var validator = Validator;
  * Instead of doing the following:
  *
  * ```javascript
- * var Validations = buildValidations({
+ * const Validations = buildValidations({
  *   username: [
  *     validator('presence', {
  *       presence: true,
@@ -174,7 +174,7 @@ export var validator = Validator;
  * We can declare default options:
  *
  * ```javascript
- * var Validations = buildValidations({
+ * const Validations = buildValidations({
  *   username: {
  *     description: 'Username'
  *     validators: [
@@ -199,7 +199,7 @@ export var validator = Validator;
  * Please note that the `message` option of a validator has its [own signature](http://offirgolan.github.io/ember-cp-validations/docs/validators/common/index.html#message).
  *
  * ```javascript
- * var Validations = buildValidations({
+ * const Validations = buildValidations({
  *   dob: validator('date', {
  *     description: 'Date of Birth',
  *     format() {

--- a/addon/validations/validator.js
+++ b/addon/validations/validator.js
@@ -18,7 +18,7 @@ const {
  * ```javascript
  * // Examples
  * validator('date', {
- *     description: 'Date of birth'
+ *   description: 'Date of birth'
  * })
  * // If validation is run and the attribute is empty, the error returned will be:
  * // 'Date of birth can't be blank'
@@ -30,13 +30,32 @@ const {
  * ```javascript
  * // Examples
  * validator('has-friends', {
- *     dependentKeys: ['friends.[]']
+ *   dependentKeys: ['friends.[]']
  * })
  * validator('has-valid-friends', {
- *     dependentKeys: ['friends.@each.username']
+ *   dependentKeys: ['friends.@each.username']
  * })
  * validator('x-validator', {
- *     dependentKeys: ['username', 'email', 'meta.foo.bar']
+ *   dependentKeys: ['username', 'email', 'meta.foo.bar']
+ * })
+ * ```
+ *
+ * ### disabled
+ * If set to `true`, disables the given validator. This option would usually go hand-in-hand
+ * with {{#crossLinkModule 'Advanced Usage'}}options as functions{{/crossLinkModule}} and `dependentKeys`. Defaults to `false`.
+ *
+ * ```js
+ * // Examples
+ * validator('presence', {
+ *   presence: true,
+ *   disabled: true
+ * })
+ * validator('presence', {
+ *   presence: true,
+ *   dependentKeys: ['shouldValidate'],
+ *   disabled() {
+ *     return !this.get('model.shouldValidate');
+ *   }
  * })
  * ```
  *
@@ -46,10 +65,10 @@ const {
  * ```javascript
  * // Examples
  * validator('length', {
- *     debounce: 500
+ *   debounce: 500
  * })
  * validator('x-validator', {
- *     debounce: 250
+ *   debounce: 250
  * })
  * ```
  *
@@ -69,12 +88,12 @@ const {
  * // Example: Function
  * validator('date', {
  *   message: function(type, options, value, context) {
- *       if (type === 'before') {
- *           return '{description} should really be before {date}';
- *       }
- *       if (type === 'after') {
- *           return '{description} should really be after {date}';
- *       }
+ *     if (type === 'before') {
+ *       return '{description} should really be before {date}';
+ *     }
+ *     if (type === 'after') {
+ *       return '{description} should really be after {date}';
+ *     }
  *   }
  * })
  * ```
@@ -99,7 +118,7 @@ const {
  * validator(function(value, options, model, attribute) {
  *   return value === options.username ? true : `must be ${options.username}`;
  * } , {
- *     username: 'John' // Any options can be passed here
+ *   username: 'John' // Any options can be passed here
  * })
  * ```
  *

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "ember-cli-inject-live-reload": "^1.3.0",
     "ember-cli-moment-shim": "0.7.1",
     "ember-cli-qunit": "^1.1.0",
-    "ember-cli-release": "^1.0.0-beta.1",
+    "ember-cli-release": "^1.0.0-beta.0",
     "ember-cli-sri": "^1.2.0",
     "ember-cli-uglify": "^1.0.1",
     "ember-cli-yuidoc": "^0.8.2",

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "ember-cli-inject-live-reload": "^1.3.0",
     "ember-cli-moment-shim": "0.7.1",
     "ember-cli-qunit": "^1.1.0",
-    "ember-cli-release": "^1.0.0-beta.0",
+    "ember-cli-release": "^1.0.0-beta.1",
     "ember-cli-sri": "^1.2.0",
     "ember-cli-uglify": "^1.0.1",
     "ember-cli-yuidoc": "^0.8.2",

--- a/tests/integration/validations/factory-dependent-keys-test.js
+++ b/tests/integration/validations/factory-dependent-keys-test.js
@@ -1,16 +1,12 @@
 import Ember from 'ember';
 import setupObject from '../../helpers/setup-object';
-import DefaultMessages from 'dummy/validators/messages';
 import CollectionValidator from 'dummy/validators/collection';
 import LengthValidator from 'dummy/validators/length';
 import { validator, buildValidations } from 'ember-cp-validations';
 import { moduleFor, test } from 'ember-qunit';
 
 moduleFor('foo', 'Integration | Validations | Factory - Dependent Keys', {
-  integration: true,
-  beforeEach() {
-    this.register('validator:messages', DefaultMessages);
-  }
+  integration: true
 });
 
 test("collection validator creates correct dependent keys", function(assert) {
@@ -65,6 +61,38 @@ test("custom dependent keys - simple", function(assert) {
   assert.equal(obj.get('validations.attrs.fullName.isValid'), true);
 });
 
+test("custom dependent keys - default options", function(assert) {
+  var Validations = buildValidations({
+    fullName: {
+      dependentKeys: ['firstName'],
+      validators: [
+        validator(function(value, options, model) {
+          let firstName = model.get('firstName');
+          let lastName = model.get('lastName');
+          if (!firstName || !lastName) {
+            return 'Full name requires first and last name';
+          }
+          return true;
+        }, {
+          dependentKeys: ['lastName']
+        })
+      ]
+    }
+  });
+
+  var obj = setupObject(this, Ember.Object.extend(Validations));
+
+  assert.equal(obj.get('validations.isValid'), false);
+  assert.equal(obj.get('validations.attrs.fullName.isValid'), false);
+  assert.equal(obj.get('validations.attrs.fullName.message'), 'Full name requires first and last name');
+
+  obj.set('firstName', 'Offir');
+  obj.set('lastName', 'Golan');
+
+  assert.equal(obj.get('validations.isValid'), true);
+  assert.equal(obj.get('validations.attrs.fullName.isValid'), true);
+});
+
 test("custom dependent keys - nested object", function(assert) {
   var Validations = buildValidations({
     page: validator(function(value, options, model) {
@@ -79,7 +107,7 @@ test("custom dependent keys - nested object", function(assert) {
     })
   });
 
-  var obj = setupObject(this, Ember.Object.extend(Validations),{
+  var obj = setupObject(this, Ember.Object.extend(Validations), {
     meta: {
       pages: {
         last: 5
@@ -117,7 +145,7 @@ test("custom dependent keys - array", function(assert) {
     })
   });
 
-  var obj = setupObject(this, Ember.Object.extend(Validations),{
+  var obj = setupObject(this, Ember.Object.extend(Validations), {
     friends: Ember.A()
   });
 
@@ -156,7 +184,7 @@ test("custom dependent keys - array of objects", function(assert) {
     })
   });
 
-  var obj = setupObject(this, Ember.Object.extend(Validations),{
+  var obj = setupObject(this, Ember.Object.extend(Validations), {
     friends: Ember.A()
   });
 


### PR DESCRIPTION
Resolves #104 

- Exposes `disabled` option for validators
- Add functionality to define `dependentKeys` in default options (should have already been there)

This will allow to do the following

```js

// Via default options
const Validations = buildValidations({
  username: {
    debounce: 500,
    disabled() { return !this.get('model._enableValidations'); },
    dependentKeys: ['_enableValidations'],
    validators: [
      validator('presence', true),
      validator('length', {
        max: 15
      })
    ]
  }
});

// Via single validator
const Validations = buildValidations({
  username: validator('presence', {
    presence: true,
    disabled() { return !this.get('model._enableValidations'); },
    dependentKeys: ['_enableValidations']
  })
});

export default DS.Model.extend(Validations, {
  'username': attr('string'),
  _enableValidations: true
});
```

@stefanpenner @rwjblue open for comments.