### PR TITLE
blueprints/validator-test: Fix typo in _filesPath() method

### DIFF
--- a/blueprints/validator-test/index.js
+++ b/blueprints/validator-test/index.js
@@ -23,7 +23,7 @@ module.exports = {
       type = 'qunit';
     } else {
       this.ui.writeLine('Couldn\'t determine test style - using QUnit');
-      testStyle = 'qunit';
+      type = 'qunit';
     }
     return path.join(this.path, type + '-files');
   },


### PR DESCRIPTION
This PR is fixing what appears to by a copy-paste/refactoring mistake in the test blueprint fallback code