### PR TITLE
Add support for nested keys in validation rules

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ __No observers were used nor harmed while developing and testing this addon.__
 * Synchronous and asynchronous support for both validators and validations
 * Dirty tracking
 * Support for nested models via `belongsTo` and `hasMany` relationships
+* Support for nested objects
 * Easily integrated with Ember Data's [DS.Errors](http://emberjs.com/api/data/classes/DS.Errors.html)
 * No observers. Seriously... there are none. Like absolutely zero....
 * Meta data based cycle tracking to detect cycles within your model relationships which could break the CP chain
@@ -228,3 +229,32 @@ const Validations = buildValidations({
   })
 });
 ```
+
+**Nested Keys**
+
+When declaring object validations (not including Ember Data models), it is possible to validate child objects from the parent object.
+
+```javascript
+import Ember from 'ember';
+import { validator, buildValidations } from 'ember-cp-validations';
+
+const Validations = buildValidations({
+  'acceptTerms': validator('inclusion', { in: [ true ] }),
+  'user.firstName': validator('presence', true),
+  'user.lasName': validator('presence', true),
+  'user.account.number': validator('number')
+});
+
+export default Ember.Component.extend(Validations, {
+  acceptTerms: false,
+  user:  { 
+    firstName: 'John', 
+    lastName: 'Doe' ,
+    account: { 
+      number: 123456, 
+    }
+  },
+  isFormValid: Ember.computed.alias('validations.isValid'),
+});
+```
+

--- a/addon/index.js
+++ b/addon/index.js
@@ -216,6 +216,35 @@ export var validator = Validator;
  *   })
  * });
  * ```
+ *
+ * <h3 id="nestedKeys">Nested Keys</h3>
+ *
+ * When declaring object validations (not including Ember Data models), it is possible to validate child objects from the parent object.
+ *
+ * ```javascript
+ * import Ember from 'ember';
+ * import { validator, buildValidations } from 'ember-cp-validations';
+ *
+ * const Validations = buildValidations({
+ *   'acceptTerms': validator('inclusion', { in: [ true ] }),
+ *   'user.firstName': validator('presence', true),
+ *   'user.lasName': validator('presence', true),
+ *   'user.account.number': validator('number')
+ * });
+ *
+ * export default Ember.Component.extend(Validations, {
+ *   acceptTerms: false,
+ *   user:  {
+ *     firstName: 'John',
+ *     lastName: 'Doe' ,
+ *     account: {
+ *       number: 123456,
+ *     }
+ *   },
+ *   isFormValid: Ember.computed.alias('validations.isValid'),
+ * });
+ * ```
+ *
  * @module Home
  * @submodule Advanced Usage
  */

--- a/addon/utils/assign.js
+++ b/addon/utils/assign.js
@@ -1,0 +1,40 @@
+/**
+ * Copyright 2016, Yahoo! Inc.
+ * Copyrights licensed under the New BSD License. See the accompanying LICENSE file for terms.
+ */
+
+/**
+ * Assigns a value to an object via the given path while creating new objects if
+ * the pathing requires it. If the given path is `foo.bar`, it will create a new object (obj.foo)
+ * and assign value to obj.foo.bar. If the given object is an Ember.Object, it will create new Ember.Objects.
+ */
+import Ember from 'ember';
+
+const {
+  get,
+  set,
+  isNone,
+  defineProperty
+} = Ember;
+
+export default function assign(obj, path, value, delimiter = '.') {
+  let keyPath = path.split(delimiter);
+  let lastKeyIndex = keyPath.length - 1;
+  let isEmberObject = obj instanceof Ember.Object;
+
+  // Iterate over each key in the path (minus the last one which is the property to be assigned)
+  for (let i = 0; i < lastKeyIndex; ++ i) {
+   let key = keyPath[i];
+   // Create a new object if it doesnt exist
+   if (isNone(get(obj, key))) {
+     set(obj, key, isEmberObject ? Ember.Object.create() : {});
+   }
+   obj = get(obj, key);
+  }
+
+  if(value instanceof Ember.ComputedProperty) {
+    defineProperty(obj, keyPath[lastKeyIndex], value);
+  } else {
+    set(obj, keyPath[lastKeyIndex], value);
+  }
+}

--- a/addon/utils/assign.js
+++ b/addon/utils/assign.js
@@ -17,17 +17,16 @@ const {
   defineProperty
 } = Ember;
 
-export default function assign(obj, path, value, delimiter = '.') {
+export default function assign(obj, path, value, useEmberObject = false, delimiter = '.') {
   let keyPath = path.split(delimiter);
   let lastKeyIndex = keyPath.length - 1;
-  let isEmberObject = obj instanceof Ember.Object;
 
   // Iterate over each key in the path (minus the last one which is the property to be assigned)
   for (let i = 0; i < lastKeyIndex; ++ i) {
    let key = keyPath[i];
    // Create a new object if it doesnt exist
    if (isNone(get(obj, key))) {
-     set(obj, key, isEmberObject ? Ember.Object.create() : {});
+     set(obj, key, useEmberObject ? Ember.Object.create() : {});
    }
    obj = get(obj, key);
   }

--- a/addon/utils/flatten.js
+++ b/addon/utils/flatten.js
@@ -1,3 +1,8 @@
+/**
+ * Copyright 2016, Yahoo! Inc.
+ * Copyrights licensed under the New BSD License. See the accompanying LICENSE file for terms.
+ */
+
 export default function flatten(array = []) {
   let result = [];
 

--- a/addon/validations/factory.js
+++ b/addon/validations/factory.js
@@ -26,7 +26,6 @@ const {
   makeArray,
   canInvoke,
   getWithDefault,
-  defineProperty,
   A: emberArray
 } = Ember;
 
@@ -105,11 +104,15 @@ function setOwner(obj, model) {
 export default function buildValidations(validations = {}) {
   processDefaultOptions(validations);
 
-  const Validations = createValidationsObject(validations);
+  var Validations;
 
   return Ember.Mixin.create({
     validations: computed(function() {
-      return Validations.create({ model: this, _parentValidations: this._super() });
+      if(!Validations) {
+        // We only want to create this once per class
+        Validations = createValidationsClass(this._super(), validations);
+      }
+      return Validations.create({ model: this });
     }).readOnly(),
     validate() {
       return get(this, 'validations').validate(...arguments);
@@ -156,86 +159,96 @@ function processDefaultOptions(validations = {}) {
 }
 
 /**
- * Creates the validations object that will become `model.validations`. Creates all necessary global CPs such as
- * `isValid`, `isAsync`, etc and also the `attrs` object.
- * @method createValidationsObject
+ * Creates the validations class that will become `model.validations`.
+ *   - Setup parent validation inheritance
+ *   - Normalize nested keys (i.e. 'details.dob') into objects (i.e { details: { dob: validator() }})
+ *   - Merge normalized validations with parent
+ *   - Create `attrs` object with CPs
+ *   - Create global CPs (i.e. 'isValid', 'messages', etc...)
+ *
+ * @method createValidationsClass
  * @private
  * @param  {Object} validations
  * @return {Ember.Object}
  */
-function createValidationsObject(validations = {}) {
-  return Ember.Object.extend({
+function createValidationsClass(inheritedValidations, validations = {}) {
+  let validationRules = {};
+  let validatableAttributes = Object.keys(validations);
+
+  // Setup validation inheritance
+  if(inheritedValidations) {
+    validationRules = merge(validationRules, inheritedValidations.get('_validationRules'));
+    validatableAttributes = emberArray(inheritedValidations.get('validatableAttributes').concat(validatableAttributes)).uniq();
+  }
+
+  // Normalize nested keys into actual objects and merge them with parent object
+  Object.keys(validations).reduce((obj, key) => {
+    assign(obj, key, validations[key]);
+    return obj;
+  }, validationRules);
+
+  // Create the CPs that will be a part of the `attrs` object
+  let attrCPs = validatableAttributes.reduce((obj, attribute) => {
+    assign(obj, attribute, createCPValidationFor(attribute, validationRules[attribute]), true);
+    return obj;
+  }, {});
+
+  // Create the mixin that holds all the top level validation props (isValid, messages, etc)
+  const TopLevelProps = createTopLevelPropsMixin(validatableAttributes);
+
+  // Create the `attrs` class which will add the current model reference once instantiated
+  const Attrs = Ember.Object.extend(attrCPs, {
+    init() {
+      this._super(...arguments);
+      let model = this.get('_model');
+
+      validatableAttributes.forEach((attribute) => {
+        // Add a reference to the model in the deepest object
+        let path = attribute.split('.');
+        let lastObject = get(this, path.slice(0, path.length  - 1).join('.'));
+        if(isNone(get(lastObject, '_model'))) {
+          set(lastObject, '_model', model);
+        }
+      });
+    }
+  });
+
+  // Create `validations` class
+  return Ember.Object.extend(TopLevelProps, {
     model: null,
     attrs: null,
     isValidations: true,
+
+    validatableAttributes: computed.alias('_validatableAttributes').readOnly(),
 
     // Caches
     _validators: null,
     _debouncedValidations: null,
 
     // Private
-    _validationRules: null,
-    _validatableAttributes: null,
-    _parentValidations: null,
+    _validationRules: computed(function() {
+      return validationRules;
+    }).readOnly(),
 
-    validatableAttributes: computed.oneWay('_validatableAttributes'),
+    _validatableAttributes: computed(function() {
+      return validatableAttributes;
+    }).readOnly(),
 
     validate,
     validateSync,
 
-    /**
-     * - Setup parent validation inheritance
-     * - Normalize nested keys (i.e. 'details.dob') into objects (i.e { details: { dob: validatior() }})
-     * - Merge normalized validations with parent
-     * - Create `attrs` object with CPs
-     * - Create global CPs (i.e. 'isValid', 'messages', etc...)
-     */
     init() {
       this._super(...arguments);
-      let validationRules = {};
-      let parentValidations = this.get('_parentValidations');
-      let validatableAttributes = Object.keys(validations);
-      let model = this.get('model');
-      let attrs = Ember.Object.create();
-
-      // Setup validation inheritance
-      if(parentValidations) {
-        validationRules = merge(validationRules, parentValidations.get('_validationRules'));
-        validatableAttributes = emberArray(parentValidations.get('_validatableAttributes').concat(validatableAttributes)).uniq();
-      }
-
-      // Normalize nested keys into actual objects and merge them with parent object
-      Object.keys(validations).reduce(( obj, key )=> {
-        assign(obj, key, validations[key]);
-        return obj;
-      }, validationRules);
-
-      // Create attrs object with CPs
-      validatableAttributes.forEach((attribute) => {
-        assign(attrs, attribute, createCPValidationFor(attribute, validationRules[attribute]));
-
-        // Add a reference to the model in the deepest object
-        let path = attribute.split('.');
-        let lastObject = get(attrs, path.slice(0, path.length  - 1).join('.'));
-        if(isNone(get(lastObject, '_model'))) {
-          set(lastObject, '_model', model);
-        }
-      });
-
       this.setProperties({
-        _validatableAttributes: validatableAttributes,
-        _validationRules: validationRules,
+        attrs: Attrs.create({ _model: this.get('model') }),
         _validators: {},
-        _debouncedValidations: {},
-        attrs
+        _debouncedValidations: {}
       });
-
-      createGlobalValidationProps(this);
     },
 
     destroy() {
       this._super(...arguments);
-      let validatableAttrs = get(this, '_validatableAttributes');
+      let validatableAttrs = get(this, 'validatableAttributes');
       let debouncedValidations = get(this, `_debouncedValidations`);
 
       // Cancel all debounced timers
@@ -288,53 +301,54 @@ function createCPValidationFor(attribute, validations) {
     return ValidationResultCollection.create({
       attribute, content: flatten(validationResults)
     });
-  }));
+  })).readOnly();
 }
 
 /**
- * Create the global properties under the validations object.
+ * Create a mixin that will have all the top level CPs under the validations object.
  * These are computed collections on different properties of each attribute validations CP
- * @method createGlobalValidationProps
+ *
+ * @method createTopLevelPropsMixin
  * @private
  * @param  {Object} validations
  */
-function createGlobalValidationProps(validations) {
-  const validatableAttrs = validations.get('validatableAttributes');
+function createTopLevelPropsMixin(validatableAttrs) {
+  return Ember.Mixin.create({
+    isValid: and(...validatableAttrs.map((attr) => `attrs.${attr}.isValid`)).readOnly(),
+    isValidating: or(...validatableAttrs.map((attr) => `attrs.${attr}.isValidating`)).readOnly(),
+    isDirty: or(...validatableAttrs.map((attr) => `attrs.${attr}.isDirty`)).readOnly(),
+    isAsync: or(...validatableAttrs.map((attr) => `attrs.${attr}.isAsync`)).readOnly(),
+    isNotValidating: not('isValidating').readOnly(),
+    isInvalid: not('isValid').readOnly(),
+    isTruelyValid: and('isValid', 'isNotValidating').readOnly(),
 
-  defineProperty(validations, 'isValid', and(...validatableAttrs.map((attr) => `attrs.${attr}.isValid`)).readOnly());
-  defineProperty(validations, 'isValidating', or(...validatableAttrs.map((attr) => `attrs.${attr}.isValidating`)).readOnly());
-  defineProperty(validations, 'isDirty', or(...validatableAttrs.map((attr) => `attrs.${attr}.isDirty`)).readOnly());
-  defineProperty(validations, 'isAsync', or(...validatableAttrs.map((attr) => `attrs.${attr}.isAsync`)).readOnly());
-  defineProperty(validations, 'isNotValidating', not('isValidating').readOnly());
-  defineProperty(validations, 'isInvalid', not('isValid').readOnly());
-  defineProperty(validations, 'isTruelyValid', and('isValid', 'isNotValidating').readOnly());
+    messages: computed(...validatableAttrs.map((attr) => `attrs.${attr}.messages`), function() {
+      return emberArray(flatten(validatableAttrs.map(attr => get(this, `attrs.${attr}.messages`)))).compact();
+    }).readOnly(),
 
-  defineProperty(validations, 'messages', computed(...validatableAttrs.map((attr) => `attrs.${attr}.messages`), function() {
-    return emberArray(flatten(validatableAttrs.map(attr => get(this, `attrs.${attr}.messages`)))).compact();
-  }).readOnly());
+    message: computed('messages.[]', cycleBreaker(function() {
+      return get(this, 'messages.0');
+    })).readOnly(),
 
-  defineProperty(validations, 'message', computed('messages.[]', cycleBreaker(function() {
-    return get(this, 'messages.0');
-  })).readOnly());
+    errors: computed(...validatableAttrs.map((attr) => `attrs.${attr}.@each.errors`), function() {
+      return emberArray(flatten(validatableAttrs.map(attr => get(this, `attrs.${attr}.errors`)))).compact();
+    }).readOnly(),
 
-  defineProperty(validations, 'errors',  computed(...validatableAttrs.map((attr) => `attrs.${attr}.@each.errors`), function() {
-    return emberArray(flatten(validatableAttrs.map(attr => get(this, `attrs.${attr}.errors`)))).compact();
-  }).readOnly());
+    error: computed('errors.[]', cycleBreaker(function() {
+      return get(this, 'errors.0');
+    })).readOnly(),
 
-  defineProperty(validations, 'error', computed('errors.[]', cycleBreaker(function() {
-    return get(this, 'errors.0');
-  })).readOnly());
-
-  defineProperty(validations, '_promise', computed(...validatableAttrs.map((attr) => `attrs.${attr}._promise`), function() {
-    var promises = [];
-    validatableAttrs.forEach((attr) => {
-      var validation = get(this, `attrs.${attr}`);
-      if (get(validation, 'isAsync')) {
-        promises.push(get(validation, '_promise'));
-      }
-    });
-    return RSVP.Promise.all(flatten(promises));
-  }).readOnly());
+    _promise: computed(...validatableAttrs.map((attr) => `attrs.${attr}._promise`), function() {
+      var promises = [];
+      validatableAttrs.forEach((attr) => {
+        var validation = get(this, `attrs.${attr}`);
+        if (get(validation, 'isAsync')) {
+          promises.push(get(validation, '_promise'));
+        }
+      });
+      return RSVP.Promise.all(flatten(promises));
+    }).readOnly()
+  });
 }
 
 /**
@@ -546,7 +560,7 @@ function validate(options = {}, async = true) {
   var blackList = makeArray(options.excludes);
   var validationResult, value;
 
-  var validationResults = get(this, '_validatableAttributes').reduce((v, name) => {
+  var validationResults = get(this, 'validatableAttributes').reduce((v, name) => {
     if (!isEmpty(blackList) && blackList.indexOf(name) !== -1) {
       return v;
     }

--- a/tests/integration/validations/factory-general-test.js
+++ b/tests/integration/validations/factory-general-test.js
@@ -534,7 +534,6 @@ test("nested keys - simple", function(assert) {
   object.set('user.lastName', 'Golan');
 
   assert.equal(object.get('validations.attrs.user.lastName.isValid'), true);
-  assert.ok(!object.get('validations.attrs._model'));
   assert.equal(object.get('validations.isValid'), true);
 });
 

--- a/tests/integration/validations/factory-general-test.js
+++ b/tests/integration/validations/factory-general-test.js
@@ -448,7 +448,7 @@ test("validations persist with inheritance", function(assert) {
 
   assert.equal(child.get('validations.errors.length'), 4);
   assert.equal(child.get('validations.isValid'), false);
-  assert.deepEqual(child.get('validations._validatableAttributes').sort(), ['firstName', 'lastName', 'middleName', 'dob'].sort());
+  assert.deepEqual(child.get('validations.validatableAttributes').sort(), ['firstName', 'lastName', 'middleName', 'dob'].sort());
 
   child.setProperties({
     middleName: 'John',
@@ -488,7 +488,7 @@ test("validations persist with deep inheritance", function(assert) {
 
   assert.equal(baby.get('validations.errors.length'), 6);
   assert.equal(baby.get('validations.isValid'), false);
-  assert.deepEqual(baby.get('validations._validatableAttributes').sort(), ['firstName', 'lastName', 'middleName', 'dob', 'diaper', 'favParent'].sort());
+  assert.deepEqual(baby.get('validations.validatableAttributes').sort(), ['firstName', 'lastName', 'middleName', 'dob', 'diaper', 'favParent'].sort());
 
   baby.setProperties({
     middleName: 'John',
@@ -592,7 +592,7 @@ test("nested keys - inheritance", function(assert) {
 
   assert.equal(child.get('validations.errors.length'), 4);
   assert.equal(child.get('validations.isValid'), false);
-  assert.deepEqual(child.get('validations._validatableAttributes').sort(), ['firstName', 'user.firstName', 'user.middleName' ,'user.lastName'].sort());
+  assert.deepEqual(child.get('validations.validatableAttributes').sort(), ['firstName', 'user.firstName', 'user.middleName' ,'user.lastName'].sort());
 
   child.setProperties({
     user: {

--- a/tests/unit/utils/assign-test.js
+++ b/tests/unit/utils/assign-test.js
@@ -1,0 +1,39 @@
+import Ember from 'ember';
+import { module, test } from 'qunit';
+import assign from 'ember-cp-validations/utils/assign';
+
+module('Unit | Utils | assign');
+
+test('single level', function(assert) {
+  let obj = {};
+  assign(obj, 'foo.bar', 1);
+  assert.deepEqual(obj, { foo: { bar: 1}});
+});
+
+test('single level - ember object', function(assert) {
+  let obj = Ember.Object.create();
+  assign(obj, 'foo.bar', 1);
+  assert.ok(obj.foo instanceof Ember.Object);
+  assert.equal(obj.get('foo.bar'), 1);
+});
+
+
+test('single level - ember object w/ CP', function(assert) {
+  let obj = Ember.Object.create();
+  assign(obj, 'foo.bar', Ember.computed(() =>  1));
+  assert.ok(obj.foo instanceof Ember.Object);
+  assert.equal(obj.get('foo.bar'), 1);
+});
+
+test('multi level', function(assert) {
+  let obj = {};
+  assign(obj, 'foo.bar.baz.boo', 1);
+  assert.deepEqual(obj, { foo: { bar: { baz: { boo: 1}}}});
+});
+
+test('multi level - ember object', function(assert) {
+  let obj = Ember.Object.create();
+  assign(obj, 'foo.bar.baz.boo', 1);
+  assert.ok(obj.foo.bar.baz instanceof Ember.Object);
+  assert.equal(obj.get('foo.bar.baz.boo'), 1);
+});

--- a/tests/unit/utils/assign-test.js
+++ b/tests/unit/utils/assign-test.js
@@ -12,7 +12,7 @@ test('single level', function(assert) {
 
 test('single level - ember object', function(assert) {
   let obj = Ember.Object.create();
-  assign(obj, 'foo.bar', 1);
+  assign(obj, 'foo.bar', 1, true);
   assert.ok(obj.foo instanceof Ember.Object);
   assert.equal(obj.get('foo.bar'), 1);
 });
@@ -20,7 +20,7 @@ test('single level - ember object', function(assert) {
 
 test('single level - ember object w/ CP', function(assert) {
   let obj = Ember.Object.create();
-  assign(obj, 'foo.bar', Ember.computed(() =>  1));
+  assign(obj, 'foo.bar', Ember.computed(() =>  1), true);
   assert.ok(obj.foo instanceof Ember.Object);
   assert.equal(obj.get('foo.bar'), 1);
 });
@@ -33,7 +33,7 @@ test('multi level', function(assert) {
 
 test('multi level - ember object', function(assert) {
   let obj = Ember.Object.create();
-  assign(obj, 'foo.bar.baz.boo', 1);
+  assign(obj, 'foo.bar.baz.boo', 1, true);
   assert.ok(obj.foo.bar.baz instanceof Ember.Object);
   assert.equal(obj.get('foo.bar.baz.boo'), 1);
 });


### PR DESCRIPTION
Resolves #131 

```js
import Ember from 'ember';
import { validator, buildValidations } from 'ember-cp-validations';

const Validations = buildValidations({
  'user.firstName': validator('presence', true),
  'user.lasName': validator('presence', true),
  'account.number': validator('presence', true),
});

export default Ember.Component.extend(Validations, {
  user:  { firstName: 'bob', lastName: 'billy' } ,
  account: { number: 123, balance: 456 }

  isFormValid: Ember.computed.alias('validations.isValid'),
});
```