### PR TITLE
make format validator phone international

### DIFF
--- a/app/validators/format.js
+++ b/app/validators/format.js
@@ -55,8 +55,23 @@ const {
 export default Base.extend({
   regularExpressions: {
     email: /^[a-zA-Z0-9.!#$%&'*+/=?^_`{|}~-]+@[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?(?:\.[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)*$/,
-    phone: /^([\+]?1\s*[-\/\.]?\s*)?(\((\d{3})\)|(\d{3}))\s*[-\/\.]?\s*(\d{3})\s*[-\/\.]?\s*(\d{4})\s*(([xX]|[eE][xX][tT]?[\.]?|extension)\s*([#*\d]+))*$/,
+    // phone: /^([\+]?1\s*[-\/\.]?\s*)?(\((\d{3})\)|(\d{3}))\s*[-\/\.]?\s*(\d{3})\s*[-\/\.]?\s*(\d{4})\s*(([xX]|[eE][xX][tT]?[\.]?|extension)\s*([#*\d]+))*$/,
     url: /(?:([A-Za-z]+):)?(\/{0,3})[a-zA-Z0-9][a-zA-Z-0-9]*(\.[\w-]+)+([\w.,@?^=%&amp;:\/~+#-{}]*[\w@?^=%&amp;\/~+#-{}])??/,
+  },
+
+  countyPhoneRegularExpressions: {
+    '+1': { // NANP
+      local: /(^([\+]?1\s*[-\/\.]?\s*)?(\((\d{3})\)|(\d{3}))\s*[-\/\.]?\s*(\d{3})\s*[-\/\.]?\s*(\d{4})\s*(([xX]|[eE][xX][tT]?[\.]?|extension)\s*([#*\d]+))*$)/,
+      international: /(^([\+]1\s*[-\/\.]?\s*)(\((\d{3})\)|(\d{3}))\s*[-\/\.]?\s*(\d{3})\s*[-\/\.]?\s*(\d{4})\s*(([xX]|[eE][xX][tT]?[\.]?|extension)\s*([#*\d]+))*$)/,
+    },
+    '+41': { // Switzerland
+      local: /(^0([1-9])([0-9]|[0-9] [0-9])*$)/,
+      international: /(^\+41 ?(\(0\) ?)?([1-9])([0-9]|[0-9 ][0-9])*$)/,
+    },
+    '+49': { // Germany
+      local: /(^0([1-9])([0-9]|[0-9] [0-9])*$)/,
+      international: /(^\+49 ?(\(0\) ?)?([1-9])([0-9]|[0-9 ][0-9])*$)/,
+    },
   },
 
   buildOptions(options = {}, defaultOptions = {}) {
@@ -65,6 +80,21 @@ export default Base.extend({
     if (options.type && !isNone(regularExpressions[options.type]) && isNone(options.regex)) {
       options.regex = regularExpressions[options.type];
     }
+
+    if(options.type === 'phone' && isNone(options.regex)) {
+      let regExArr = [];
+      let defaultCountryCode = options.defaultCountryCode || options.defaultCountryCode !== null && '+1' || null;
+      let countyPhoneRegularExpressions = get(this, 'countyPhoneRegularExpressions');
+      if(defaultCountryCode) {
+        regExArr.push(countyPhoneRegularExpressions[defaultCountryCode].local);
+      }
+      Object.keys(countyPhoneRegularExpressions).forEach(key => {
+        regExArr.push(countyPhoneRegularExpressions[key].international);
+      });
+
+      options.regex = new RegExp(regExArr.map(r => r.toString()).map(str => str.substr(1, str.length-2)).join('|'));
+    }
+
     return this._super(options, defaultOptions);
   },
 

--- a/tests/unit/validators/format-test.js
+++ b/tests/unit/validators/format-test.js
@@ -70,7 +70,7 @@ test('email', function(assert) {
   assert.equal(message, true);
 });
 
-test('phone', function(assert) {
+test('phone, default local', function(assert) {
   assert.expect(2);
 
   options = {
@@ -83,6 +83,102 @@ test('phone', function(assert) {
   assert.equal(message, 'This field must be a valid phone number');
 
   message = validator.validate('(408) 555-1234', options);
+  assert.equal(message, true);
+});
+
+test('phone, +41 international', function(assert) {
+  assert.expect(5);
+
+  options = {
+    type: 'phone'
+  };
+
+  options = validator.buildOptions(options, {});
+
+  message = validator.validate('+41 0123', options);
+  assert.equal(message, 'This field must be a valid phone number');
+
+  message = validator.validate('+41 (0)11 111 11 11 ', options);
+  assert.equal(message, 'This field must be a valid phone number');
+
+  message = validator.validate('+41 11 111 11 11', options);
+  assert.equal(message, true);
+
+  message = validator.validate('+41 (0)11 111 11 11', options);
+  assert.equal(message, true);
+
+  message = validator.validate('+41111111111', options);
+  assert.equal(message, true);
+});
+
+test('phone, +41 local', function(assert) {
+  assert.expect(4);
+
+  options = {
+    type: 'phone',
+    defaultCountryCode: '+41'
+  };
+
+  options = validator.buildOptions(options, {});
+
+  message = validator.validate('(408) 555-1234', options); // valid US number but not valid CH number
+  assert.equal(message, 'This field must be a valid phone number');
+
+  message = validator.validate('+1 (408) 555-1234', options); // international US must still work
+  assert.equal(message, true);
+
+  message = validator.validate('011 111 11 11', options);
+  assert.equal(message, true);
+
+  message = validator.validate('0111111111', options);
+  assert.equal(message, true);
+});
+
+test('phone, +49 international', function(assert) {
+  assert.expect(5);
+
+  options = {
+    type: 'phone'
+  };
+
+  options = validator.buildOptions(options, {});
+
+  message = validator.validate('+49 0123', options);
+  assert.equal(message, 'This field must be a valid phone number');
+
+  message = validator.validate('+49 (0)11 111 11 11 ', options);
+  assert.equal(message, 'This field must be a valid phone number');
+
+  message = validator.validate('+49 11 111 11 11', options);
+  assert.equal(message, true);
+
+  message = validator.validate('+49 (0)11 111 11 11', options);
+  assert.equal(message, true);
+
+  message = validator.validate('+49111111111', options);
+  assert.equal(message, true);
+});
+
+test('phone, +49 local', function(assert) {
+  assert.expect(4);
+
+  options = {
+    type: 'phone',
+    defaultCountryCode: '+49'
+  };
+
+  options = validator.buildOptions(options, {});
+
+  message = validator.validate('(408) 555-1234', options); // valid US number but not valid CH number
+  assert.equal(message, 'This field must be a valid phone number');
+
+  message = validator.validate('+1 (408) 555-1234', options); // international US must still work
+  assert.equal(message, true);
+
+  message = validator.validate('011 111 11 11', options);
+  assert.equal(message, true);
+
+  message = validator.validate('0111111111', options);
   assert.equal(message, true);
 });
 


### PR DESCRIPTION
The format validator can now recognize international numbers from germany and switzerland and is extensible for more country codes.

Should fix #141 