### PR TITLE
Global options support

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -2,3 +2,4 @@ languages:
   JavaScript: true
 exclude_paths:
 - "tests/*"
+- "config/*"

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,6 +28,7 @@ env:
 matrix:
   fast_finish: true
   allow_failures:
+    - env: EMBER_TRY_SCENARIO=ember-beta
     - env: EMBER_TRY_SCENARIO=ember-canary
 
 before_install:
@@ -42,7 +43,7 @@ install:
   - bower install
 
 script:
-  - ember try:one $EMBER_TRY_SCENARIO ember test
+  - ember try:one $EMBER_TRY_SCENARIO --- ember test
 
 after_script:
   - codeclimate-test-reporter < lcov.dat

--- a/addon/index.js
+++ b/addon/index.js
@@ -38,10 +38,7 @@ export var validator = Validator;
  *
  * import Ember from 'ember';
  * import DS from 'ember-data';
- * import {
- *   validator, buildValidations
- * }
- * from 'ember-cp-validations';
+ * import { validator, buildValidations } from 'ember-cp-validations';
  *
  * const Validations = buildValidations({
  *   username: validator('presence', true),
@@ -88,10 +85,7 @@ export var validator = Validator;
  * // components/x-foo.js
  *
  * import Ember from 'ember';
- * import {
- *   validator, buildValidations
- * }
- * from 'ember-cp-validations';
+ * import { validator, buildValidations } from 'ember-cp-validations';
  *
  * const Validations = buildValidations({
  *   bar: validator('presence', true)
@@ -193,6 +187,46 @@ export var validator = Validator;
  * ```
  *
  * In the above example, all the validators for username will have a description of `Username` except that of the `no-whitespace-around` validator which will be `A username`.
+ *
+ * <h3 id="globalOptions">Global Options</h3>
+ *
+ * If you have  specific options you want to propagate throught all your validation rules, you can do so by passing in a global options object.
+ * This is ideal for when you have a dependent key that each validator requires such as the current locale from your i18n implementation, or
+ * you want easily toggle your validations on/off.
+ *
+ * ```javascript
+ * const Validations = buildValidations(validationRules, globalOptions);
+ * ```
+ *
+ * ```javascript
+ * import Ember from 'ember';
+ * import { validator, buildValidations } from 'ember-cp-validations';
+ *
+ * const Validations = buildValidations({
+ *   firstName: {
+ *     description: 'First Name'
+ *     validators: [
+ *       validator('presence', {
+ *         presence: true,
+ *         dependentKeys: ['foo', 'bar']
+ *       })
+ *      ]
+ *    },
+ *   lastName: validator('presence', true)
+ * }, {
+ *   description: 'This field'
+ *   dependentKeys: ['i18n.locale', 'disableValidations'],
+ *   disabled() {
+ *     return this.get('model.disableValidations');
+ *   }
+ * });
+ * ```
+ *
+ * Just like in the default options, locale validator options will always take precedence over default options and default options will always take precedence
+ * over global options. This allows you to declare global rules while having the ability to override them in lower levels.
+ *
+ * This rule does not apply to `dependentKeys`, instead they all are merged. In the example above, __firstName__'s dependentKeys will be
+ * `['i18n.locale', 'disableValidations', 'foo', 'bar']`
  *
  * <h3 id="optionsAsFunctions">Options as Functions</h3>
  *

--- a/addon/validators/base.js
+++ b/addon/validators/base.js
@@ -27,11 +27,18 @@ export default Ember.Object.extend({
   options: undefined,
 
   /**
-   * Default validations options for this specific attribute
+   * Default validation options for this specific attribute
    * @property defaultOptions
    * @type {Object}
    */
   defaultOptions: undefined,
+
+  /**
+   * Global validation options for this model
+   * @property globalOptions
+   * @type {Object}
+   */
+  globalOptions: undefined,
 
   /**
    * Model instance
@@ -67,6 +74,7 @@ export default Ember.Object.extend({
     var owner = getOwner(this);
     var options = get(this, 'options');
     var defaultOptions = get(this, 'defaultOptions');
+    var globalOptions = get(this, 'globalOptions');
     var errorMessages;
 
     if (!isNone(owner)) {
@@ -77,7 +85,7 @@ export default Ember.Object.extend({
     // If for some reason, we can't find the messages object (i.e. unit tests), use default
     errorMessages = errorMessages || Messages;
 
-    set(this, 'options', this.buildOptions(options, defaultOptions));
+    set(this, 'options', this.buildOptions(options, defaultOptions, globalOptions));
     set(this, 'errorMessages', errorMessages.create());
   },
 
@@ -88,16 +96,11 @@ export default Ember.Object.extend({
    * @method buildOptions
    * @param  {Object} options
    * @param  {Object} defaultOptions
+   * @param  {Object} globalOptions
    * @return {Object}
    */
-  buildOptions(options = {}, defaultOptions = {}) {
-    Object.keys(defaultOptions).forEach(key => {
-      if (isNone(options[key])) {
-        options[key] = defaultOptions[key];
-      }
-    });
-
-    return options;
+  buildOptions(options = {}, defaultOptions = {}, globalOptions = {}) {
+    return merge(merge(merge({}, globalOptions), defaultOptions), options);
   },
 
   /**

--- a/app/validators/collection.js
+++ b/app/validators/collection.js
@@ -28,13 +28,29 @@ const {
  *  @extends Base
  */
 export default Base.extend({
-  buildOptions(options, defaultOptions) {
+  /**
+   * Normalized options passed in.
+   * ```js
+   * validator('collection', true)
+   * // Becomes
+   * validator('collection', {
+   *   collection: true
+   * })
+   * ```
+   *
+   * @method buildOptions
+   * @param  {Object}     options
+   * @param  {Object}     defaultOptions
+   * @param  {Object}     globalOptions
+   * @return {Object}
+   */
+  buildOptions(options = {}, defaultOptions = {}, globalOptions = {}) {
     if(typeof options === 'boolean') {
       options = {
         collection: options
       };
     }
-    return this._super(options, defaultOptions);
+    return this._super(options, defaultOptions, globalOptions);
   },
 
   validate(value, options) {

--- a/app/validators/format.js
+++ b/app/validators/format.js
@@ -59,13 +59,23 @@ export default Base.extend({
     url: /(?:([A-Za-z]+):)?(\/{0,3})[a-zA-Z0-9][a-zA-Z-0-9]*(\.[\w-]+)+([\w.,@?^=%&amp;:\/~+#-{}]*[\w@?^=%&amp;\/~+#-{}])??/,
   },
 
-  buildOptions(options = {}, defaultOptions = {}) {
+  /**
+   * Normalized options passed in by applying the desired regex or using the one declared
+   *
+   * @method buildOptions
+   * @param  {Object}     options
+   * @param  {Object}     defaultOptions
+   * @param  {Object}     globalOptions
+   * @return {Object}
+   */
+  buildOptions(options = {}, defaultOptions = {}, globalOptions = {}) {
     var regularExpressions = get(this, 'regularExpressions');
 
     if (options.type && !isNone(regularExpressions[options.type]) && isNone(options.regex)) {
       options.regex = regularExpressions[options.type];
     }
-    return this._super(options, defaultOptions);
+
+    return this._super(options, defaultOptions, globalOptions);
   },
 
   validate(value, options) {

--- a/app/validators/presence.js
+++ b/app/validators/presence.js
@@ -38,18 +38,20 @@ export default Base.extend({
    *   presence: true
    * })
    * ```
+   *
    * @method buildOptions
    * @param  {Object}     options
    * @param  {Object}     defaultOptions
+   * @param  {Object}     globalOptions
    * @return {Object}
    */
-  buildOptions(options, defaultOptions) {
+  buildOptions(options = {}, defaultOptions = {}, globalOptions = {}) {
     if(typeof options === 'boolean') {
       options = {
         presence: options
       };
     }
-    return this._super(options, defaultOptions);
+    return this._super(options, defaultOptions, globalOptions);
   },
 
   validate(value, options) {

--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
   "dependencies": {
     "ember-cli-babel": "^5.1.5",
     "ember-cli-version-checker": "^1.1.4",
-    "ember-getowner-polyfill": "^1.0.0",
+    "ember-getowner-polyfill": "^1.0.1",
     "exists-sync": "0.0.3",
     "walk-sync": "^0.2.0"
   },

--- a/tests/dummy/app/app.js
+++ b/tests/dummy/app/app.js
@@ -4,7 +4,7 @@
  */
 
 import Ember from 'ember';
-import Resolver from 'ember-resolver';
+import Resolver from './resolver';
 import loadInitializers from 'ember-load-initializers';
 import config from './config/environment';
 

--- a/tests/dummy/app/models/user-detail.js
+++ b/tests/dummy/app/models/user-detail.js
@@ -14,17 +14,10 @@ from 'ember-cp-validations';
 var attr = DS.attr;
 
 var Validations = buildValidations({
-  firstName: validator('presence', {
-    presence: true,
-    debounce: 500
-  }),
-  lastName: validator('presence', {
-    presence: true,
-    debounce: 500
-  }),
+  firstName: validator('presence', true),
+  lastName: validator('presence', true),
   dob: {
     description: 'Date of  birth',
-    debounce: 500,
     validators: [
       validator('presence', true),
       validator('date', {
@@ -47,18 +40,17 @@ var Validations = buildValidations({
   phone: [
     validator('format', {
       allowBlank: true,
-      debounce: 500,
       type: 'phone'
     })
   ],
   url: [
     validator('format', {
       allowBlank: true,
-      debounce: 500,
       type: 'url'
     })
   ]
-
+}, {
+  debounce: 500
 });
 
 export default DS.Model.extend(Validations, {

--- a/tests/dummy/app/models/user.js
+++ b/tests/dummy/app/models/user.js
@@ -11,7 +11,7 @@ var attr = DS.attr;
 
 var Validations = buildValidations({
   username: {
-    debounce: 500,
+    description: 'Username',
     validators: [
       validator('presence', true),
       validator('length', {
@@ -21,7 +21,6 @@ var Validations = buildValidations({
   },
   password: {
     description: 'Password',
-    debounce: 500,
     validators: [
       validator('presence', true),
       validator('length', {
@@ -35,7 +34,6 @@ var Validations = buildValidations({
     ]
   },
   email: {
-    debounce: 500,
     validators: [
       validator('presence', true),
       validator('format', {
@@ -45,10 +43,11 @@ var Validations = buildValidations({
   },
   emailConfirmation: validator('confirmation', {
     on: 'email',
-    message: 'Email addresses do not match',
-    debounce: 500
+    message: 'Email addresses do not match'
   }),
   details: validator('belongs-to')
+}, {
+  debounce: 500
 });
 
 export default DS.Model.extend(Validations, {

--- a/tests/dummy/app/resolver.js
+++ b/tests/dummy/app/resolver.js
@@ -1,0 +1,3 @@
+import Resolver from 'ember-resolver';
+
+export default Resolver;

--- a/tests/helpers/setup-object.js
+++ b/tests/helpers/setup-object.js
@@ -1,10 +1,5 @@
-import Ember from 'ember';
+import getOwner from 'ember-getowner-polyfill';
 
 export default function(context, obj, options = {}) {
-  if(Ember.setOwner) {
-    Ember.setOwner(options, Ember.getOwner(context));
-  } else {
-    options.container = context.container;
-  }
-  return obj.create(options);
+  return obj.create(getOwner(context).ownerInjection(), options);
 }

--- a/tests/integration/validations/factory-dependent-keys-test.js
+++ b/tests/integration/validations/factory-dependent-keys-test.js
@@ -115,6 +115,46 @@ test("custom dependent keys - default options", function(assert) {
   assert.equal(obj.get('validations.attrs.fullName.isValid'), true);
 });
 
+test("custom dependent keys - global options", function(assert) {
+  var Validations = buildValidations({
+    fullName: {
+      dependentKeys: ['firstName'],
+      validators: [
+        validator(function(value, options, model) {
+          let firstName = model.get('firstName');
+          let lastName = model.get('lastName');
+          let middleName = model.get('middleName');
+          if (!firstName || !lastName || !middleName) {
+            return 'Full name requires first, middle, and last name';
+          }
+          return true;
+        }, {
+          dependentKeys: ['lastName']
+        })
+      ]
+    }
+  }, {
+    dependentKeys: ['middleName']
+  });
+
+  var obj = setupObject(this, Ember.Object.extend(Validations));
+
+  assert.equal(obj.get('validations.isValid'), false);
+  assert.equal(obj.get('validations.attrs.fullName.isValid'), false);
+  assert.equal(obj.get('validations.attrs.fullName.message'), 'Full name requires first, middle, and last name');
+
+  obj.set('firstName', 'Offir');
+  obj.set('lastName', 'Golan');
+
+  assert.equal(obj.get('validations.isValid'), false);
+  assert.equal(obj.get('validations.attrs.fullName.isValid'), false);
+
+  obj.set('middleName', 'David');
+
+  assert.equal(obj.get('validations.isValid'), true);
+  assert.equal(obj.get('validations.attrs.fullName.isValid'), true);
+});
+
 test("custom dependent keys - nested object", function(assert) {
   var Validations = buildValidations({
     page: validator(function(value, options, model) {

--- a/tests/integration/validations/factory-general-test.js
+++ b/tests/integration/validations/factory-general-test.js
@@ -235,6 +235,42 @@ test("default options", function(assert) {
   assert.equal(rules[0].defaultOptions.description, 'Test field');
 });
 
+test("global options", function(assert) {
+  this.register('validator:length', LengthValidator);
+
+  var Validations = buildValidations({
+    firstName: {
+      description: 'Test field',
+      validators: [
+        validator('length', {min: 1, max: 5}),
+      ]
+    }
+  }, {
+    message: 'Global error message',
+    description: 'Default field',
+    max: 10
+  });
+
+  var object = setupObject(this, Ember.Object.extend(Validations), {
+    firstName: ''
+  });
+
+  // Global options present in rules
+  var rules = Ember.A(object.get('validations._validationRules.firstName'));
+  assert.equal(rules.isAny('globalOptions', undefined), false);
+  assert.equal(rules[0].globalOptions.max, 10);
+
+  assert.ok(object.get('validations.attrs.firstName.isInvalid'));
+
+  var v = object.get('validations._validators.firstName.0');
+  assert.deepEqual(v.get('options'), {
+    message: 'Global error message',
+    description: 'Test field',
+    min: 1,
+    max: 5
+  });
+});
+
 test("custom messages object", function(assert) {
   this.register('validator:messages', DefaultMessages);
   var Validations = buildValidations({


### PR DESCRIPTION
If you have  specific options you want to propagate throught all your validation rules, you can do so by passing in a global options object.
This is ideal for when you have a dependent key that each validator requires such as the current locale from your i18n implementation, or
you want easily toggle your validations on/off.

```javascript
const Validations = buildValidations(validationRules, globalOptions);
```

```javascript
import Ember from 'ember';
import { validator, buildValidations } from 'ember-cp-validations';
const Validations = buildValidations({
  firstName: {
    description: 'First Name'
    validators: [
      validator('presence', {
        presence: true,
        dependentKeys: ['foo', 'bar']
      })
     ]
   },
  lastName: validator('presence', true)
}, {
  description: 'This field'
  dependentKeys: ['i18n.locale', 'disableValidations'],
  disabled() {
    return this.get('model.disableValidations');
  }
});
```

Just like in the default options, locale validator options will always take precedence over default options and default options will always take precedence
over global options. This allows you to declare global rules while having the ability to override them in lower levels.
This rule does not apply to `dependentKeys`, instead they all are merged. In the example above, __firstName__'s dependentKeys will be
`['i18n.locale', 'disableValidations', 'foo', 'bar']`