### PR TITLE
Fix deprecation warning Ember.merge > Ember.assign for ember@2.5.0 

### DIFF
--- a/addon/validations/factory.js
+++ b/addon/validations/factory.js
@@ -17,7 +17,6 @@ const {
   set,
   run,
   RSVP,
-  merge,
   isNone,
   guidFor,
   isEmpty,
@@ -28,6 +27,8 @@ const {
   getWithDefault,
   A: emberArray
 } = Ember;
+
+const merge = Ember.assign || Ember.merge;
 
 const {
   Promise

--- a/addon/validators/base.js
+++ b/addon/validators/base.js
@@ -10,9 +10,10 @@ import getOwner from 'ember-getowner-polyfill';
 const {
   get,
   set,
-  merge,
   isNone
 } = Ember;
+
+const assign = Ember.assign || Ember.merge;
 
 /**
  * @class Base
@@ -101,7 +102,7 @@ export default Ember.Object.extend({
    * @return {Object}
    */
   buildOptions(options = {}, defaultOptions = {}, globalOptions = {}) {
-    return merge(merge(merge({}, globalOptions), defaultOptions), options);
+    return assign(assign(assign({}, globalOptions), defaultOptions), options);
   },
 
   /**
@@ -111,7 +112,7 @@ export default Ember.Object.extend({
    * @return {Object}
    */
   processOptions() {
-    const options = merge({}, get(this, 'options') || {});
+    const options = assign({}, get(this, 'options') || {});
 
     Object.keys(options).forEach(key => {
       const opt = options[key];

--- a/tests/helpers/start-app.js
+++ b/tests/helpers/start-app.js
@@ -3,11 +3,13 @@ import Application from '../../app';
 import Router from '../../router';
 import config from '../../config/environment';
 
+const assign = Ember.assign || Ember.merge;
+
 export default function startApp(attrs) {
   var application;
 
-  var attributes = Ember.merge({}, config.APP);
-  attributes = Ember.merge(attributes, attrs); // use defaults, but you can override;
+  var attributes = assign({}, config.APP);
+  attributes = assign(attributes, attrs); // use defaults, but you can override;
 
   Ember.run(function() {
     application = Application.create(attributes);


### PR DESCRIPTION
Hi, this is a fix for the deprecation of Ember.merge:
DEPRECATION: Usage of Ember.merge is deprecated, use Ember.assign instead. [deprecation id: ember-metal.merge]

More info: https://github.com/emberjs/ember.js/pull/12303