### PR TITLE
Introduce `ignoreWhitespace` in presence validator

### DIFF
--- a/addon/validators/presence.js
+++ b/addon/validators/presence.js
@@ -8,7 +8,8 @@ import Base from './base';
 
 const {
   get,
-  isEmpty
+  isEmpty,
+  isPresent
 } = Ember;
 
 /**
@@ -21,6 +22,13 @@ const {
  *  validator('presence', {
  *    presence: true,
  *    message: 'should not be empty'
+ *  })
+ *
+ *  If you want whitespace to be ignored, use `ignoreWhitespace: true`:
+ *
+ *  validator('presence', {
+ *    ignoreWhitespace: true,
+ *    message: 'should not be empty or consist only of spaces'
  *  })
  *  ```
  *
@@ -58,11 +66,11 @@ export default Base.extend({
   },
 
   validate(value, options) {
-    if (options.presence === true && !this._isPresent(value)) {
+    if (options.presence === true && !this._isPresent(value, options.ignoreWhitespace)) {
       return this.createErrorMessage('blank', value, options);
     }
 
-    if (options.presence === false && this._isPresent(value)) {
+    if (options.presence === false && this._isPresent(value, options.ignoreWhitespace)) {
       return this.createErrorMessage('present', value, options);
     }
 
@@ -72,10 +80,15 @@ export default Base.extend({
   /**
    * Handle presence of ember proxy based instances
    */
-  _isPresent(value) {
+  _isPresent(value, ignoreWhitespace) {
     if (value instanceof Ember.ObjectProxy || value instanceof Ember.ArrayProxy) {
-      return this._isPresent(get(value, 'content'));
+      return this._isPresent(get(value, 'content'), ignoreWhitespace);
     }
-    return !isEmpty(value);
+
+    if (ignoreWhitespace) {
+      return isPresent(value);
+    } else {
+      return !isEmpty(value);
+    }
   }
 });

--- a/tests/unit/validators/presence-test.js
+++ b/tests/unit/validators/presence-test.js
@@ -39,6 +39,22 @@ test('presence - value present', function(assert) {
   assert.equal(message, true);
 });
 
+test('presence - value blank', function(assert) {
+  assert.expect(1);
+
+  options = { presence: true };
+  message = validator.validate(' ', options);
+  assert.equal(message, true);
+});
+
+test('presence with ignoreWhitespace - value blank', function(assert) {
+  assert.expect(1);
+
+  options = { presence: true, ignoreWhitespace: true };
+  message = validator.validate(' ', options);
+  assert.equal(message, "This field can't be blank");
+});
+
 test('presence - value not present', function(assert) {
   assert.expect(1);
 
@@ -46,7 +62,6 @@ test('presence - value not present', function(assert) {
   message = validator.validate(undefined, options);
   assert.equal(message, "This field can't be blank");
 });
-
 
 test('absence - value present', function(assert) {
   assert.expect(1);


### PR DESCRIPTION
This allows using a validator for a case when value should not consist only of space(s).