### PR TITLE
Expose dependent keys api to validators

### DIFF
--- a/addon/validators/alias.js
+++ b/addon/validators/alias.js
@@ -33,7 +33,7 @@ const {
  *  @module Validators
  *  @extends Base
  */
-export default Base.extend({
+const Alias = Base.extend({
 
   /**
    * Normalized options passed in.
@@ -74,3 +74,12 @@ export default Base.extend({
     return firstMessageOnly ? get(aliasValidation, 'message') : get(aliasValidation, 'content');
   }
 });
+
+Alias.reopenClass({
+  getDependentsFor(attribute, options) {
+    const alias = typeof options === 'string' ? options : options.alias;
+    return [ `${alias}.messages.[]`, `${alias}.isTruelyValid` ];
+  }
+});
+
+export default Alias;

--- a/addon/validators/base.js
+++ b/addon/validators/base.js
@@ -19,7 +19,7 @@ const assign = Ember.assign || Ember.merge;
  * @class Base
  * @module Validators
  */
-export default Ember.Object.extend({
+const Base = Ember.Object.extend({
 
   /**
    * Options passed in to the validator when defined in the model
@@ -150,7 +150,7 @@ export default Ember.Object.extend({
 
   /**
    * Wrapper method to `value` that passes the necessary parameters
-   * 
+   *
    * @method getValue
    * @private
    * @return {Unknown} value
@@ -230,6 +230,23 @@ export default Ember.Object.extend({
     return message.trim();
   }
 });
+
+Base.reopenClass({
+  /**
+   * Generate the needed depenent keys for this validator
+   *
+   * @method getDependentsFor
+   * @static
+   * @param  {String} attribute
+   * @param  {Object} options
+   * @return {Array} dependent keys
+   */
+  getDependentsFor() {
+    return [];
+  }
+});
+
+export default Base;
 
 /**
  * Creating custom validators is very simple. To generate a validator named `unique-username` in Ember CLI

--- a/addon/validators/base.js
+++ b/addon/validators/base.js
@@ -263,15 +263,21 @@ export default Base;
  * ```javascript
  * // app/validators/unique-username.js
  *
- * import Ember from 'ember';
  * import BaseValidator from 'ember-cp-validations/validators/base';
  *
- * export default BaseValidator.extend({
+ * const UniqueUsername = BaseValidator.extend({
  *   validate(value, options, model, attribute) {
  *     return true;
- *     })
  *   }
  * });
+ *
+ * UniqueUsername.reopenClass({
+ *   getDependentsFor(attribute, options) {
+ *     return [];
+ *   }
+ * });
+ *
+ * export default UniqueUsername;
  * ```
  *
  * **Side Node**: Before we continue, I would suggest checking out the documentation for the {{#crossLink 'Base'}}Base Validator{{/crossLink}}.
@@ -285,7 +291,7 @@ export default Base;
  * import Ember from 'ember';
  * import BaseValidator from 'ember-cp-validations/validators/base';
  *
- * export default BaseValidator.extend({
+ * const UniqueUsername = BaseValidator.extend({
  *   store: Ember.inject.service(),
  *
  *   validate(value, options, model, attribute) {
@@ -305,6 +311,37 @@ export default Base;
  *   }
  * });
  * ```
+ *
+ * ## Dependent Keys
+ *
+ * There will be times when your validator will be dependent on some other property or object. Instead of having to
+ * include them in your option's `dependentKeys`, you can declare them in the static `getDependentsFor` hook. This hook
+ * recieves two parameters. The first is the `attribute` that this validator is being added to, and the second are the `options`
+ * there were passed to this validator.
+ *
+ * From the above code sample:
+ *
+ * ```javascript
+ * // app/validators/unique-username.js
+ *
+ * import BaseValidator from 'ember-cp-validations/validators/base';
+ *
+ * const UniqueUsername = BaseValidator.extend({});
+ *
+ * UniqueUsername.reopenClass({
+ *   getDependentsFor(attribute, options) {
+ *     return [];
+ *   }
+ * });
+ *
+ * export default UniqueUsername;
+ * ```
+ *
+ * All dependent keys are in reference to the model. So when you return `['username']`, it will add a dependent to `model.username`.
+ * This means that if you have a dependent on a service, that service must be injected into the model since returning `['myService.someProperty']`
+ * will be interpreted as `model.myService.someProperty`.
+ *
+ * ## Usage
  *
  * To use our unique-username validator we just have to add it to the model definition
  *

--- a/addon/validators/belongs-to.js
+++ b/addon/validators/belongs-to.js
@@ -79,7 +79,7 @@ const {
  *  @module Validators
  *  @extends Base
  */
-export default Base.extend({
+const BelongsTo = Base.extend({
   validate(value) {
     if (value) {
       if (canInvoke(value, 'then')) {
@@ -91,3 +91,11 @@ export default Base.extend({
     return true;
   }
 });
+
+BelongsTo.reopenClass({
+  getDependentsFor(attribute) {
+    return [ `${attribute}.isTruelyValid` ];
+  }
+});
+
+export default BelongsTo;

--- a/addon/validators/collection.js
+++ b/addon/validators/collection.js
@@ -28,7 +28,7 @@ const {
  *  @module Validators
  *  @extends Base
  */
-export default Base.extend({
+const Collection = Base.extend({
 
   /**
    * Normalized options passed in.
@@ -69,3 +69,11 @@ export default Base.extend({
     return true;
   }
 });
+
+Collection.reopenClass({
+  getDependentsFor(attribute, options) {
+    return (options === true || options.collection === true) ? [ `_model.${attribute}.[]` ] : [];
+  }
+});
+
+export default Collection;

--- a/addon/validators/confirmation.js
+++ b/addon/validators/confirmation.js
@@ -33,7 +33,7 @@ const {
  *  @module Validators
  *  @extends Base
  */
-export default Base.extend({
+const Confirmation = Base.extend({
   validate(value, options, model) {
     if (!isNone(options.on) && !isEqual(value, get(model, options.on))) {
       return this.createErrorMessage('confirmation', value, options);
@@ -42,3 +42,11 @@ export default Base.extend({
     return true;
   }
 });
+
+Confirmation.reopenClass({
+  getDependentsFor(attribute, options) {
+    return options.on ? [ `_model.${options.on}` ] : [];
+  }
+});
+
+export default Confirmation;

--- a/addon/validators/dependent.js
+++ b/addon/validators/dependent.js
@@ -30,7 +30,7 @@ const {
  *  @module Validators
  *  @extends Base
  */
-export default Base.extend({
+const Dependent = Base.extend({
   validate(value, options, model) {
     if (isNone(options) || isNone(model) || isEmpty(Object.keys(options))) {
       return true;
@@ -53,3 +53,17 @@ export default Base.extend({
     return true;
   }
 });
+
+Dependent.reopenClass({
+  getDependentsFor(attribute, options) {
+    const dependents = options.on;
+
+    if (!isEmpty(dependents)) {
+      return dependents.map(dependent => `${dependent}.isTruelyValid`);
+    }
+
+    return [];
+  }
+});
+
+export default Dependent;

--- a/addon/validators/ds-error.js
+++ b/addon/validators/ds-error.js
@@ -29,7 +29,7 @@ const {
  *  @module Validators
  *  @extends Base
  */
-export default Base.extend({
+const DSError = Base.extend({
   validate(value, options, model, attribute) {
     const errors = get(model, 'errors');
 
@@ -40,3 +40,11 @@ export default Base.extend({
     return true;
   }
 });
+
+DSError.reopenClass({
+  getDependentsFor(attribute) {
+    return [ `_model.errors.${attribute}.[]` ];
+  }
+});
+
+export default DSError;

--- a/addon/validators/has-many.js
+++ b/addon/validators/has-many.js
@@ -55,7 +55,7 @@ const {
  *  @module Validators
  *  @extends Base
  */
-export default Base.extend({
+const HasMany = Base.extend({
   validate(value) {
     if (value) {
       if (canInvoke(value, 'then')) {
@@ -67,3 +67,11 @@ export default Base.extend({
     return true;
   }
 });
+
+HasMany.reopenClass({
+  getDependentsFor(attribute) {
+    return [ `${attribute}.@each.isTruelyValid` ];
+  }
+});
+
+export default HasMany;

--- a/blueprints/validator/files/app/validators/__name__.js
+++ b/blueprints/validator/files/app/validators/__name__.js
@@ -1,7 +1,22 @@
 import BaseValidator from 'ember-cp-validations/validators/base';
 
-export default BaseValidator.extend({
+const <%= classifiedModuleName %> = BaseValidator.extend({
   validate(/*value, options, model, attribute*/) {
     return true;
   }
 });
+
+<%= classifiedModuleName %>.reopenClass({
+  /**
+   * Define attribute specific dependent keys for your validator
+   *
+   * @param {String}  attribute   The attribute being evaluated
+   * @param {Unknown} options     Options passed into your validator
+   * @return {Array}
+   */
+  getDependentsFor(/* attribute, options */) {
+    return [];
+  }
+});
+
+export default <%= classifiedModuleName %>;

--- a/tests/unit/validations/ds-model-test.js
+++ b/tests/unit/validations/ds-model-test.js
@@ -6,7 +6,7 @@ import {
 from 'ember-qunit';
 
 moduleForModel('signup', 'Unit | Validations | DS.Model', {
-
+  needs: ['validator:presence']
 });
 
 test('create model with defaults', function(assert) {

--- a/tests/unit/validators/date-test.js
+++ b/tests/unit/validators/date-test.js
@@ -158,11 +158,11 @@ test('before or on percision', function(assert) {
     message = validator.validate(dateString, { onOrBefore: dateString });
     assert.equal(message, true);
 
-    message = validator.validate(moment(dateString).add(1, percision), { onOrBefore: dateString });
+    message = validator.validate(moment(new Date(dateString)).add(1, percision), { onOrBefore: dateString });
     assert.equal(message, `This field must be on or before ${nowMessage}`);
 
     if ((i + 1) !== percisions.length) {
-      message = validator.validate(moment(dateString).add(1, percisions), { onOrBefore: dateString, percision: percisions[i + 1] });
+      message = validator.validate(moment(new Date(dateString)).add(1, percisions), { onOrBefore: dateString, percision: percisions[i + 1] });
       assert.equal(message, true);
     }
   }
@@ -246,11 +246,11 @@ test('after or on percision', function(assert) {
     message = validator.validate(dateString, { onOrAfter: dateString });
     assert.equal(message, true);
 
-    message = validator.validate(moment(dateString).subtract(1, percision), { onOrAfter: dateString });
+    message = validator.validate(moment(new Date(dateString)).subtract(1, percision), { onOrAfter: dateString });
     assert.equal(message, `This field must be on or after ${nowMessage}`);
 
     if ((i + 1) !== percisions.length) {
-      message = validator.validate(moment(dateString).subtract(1, percisions), { onOrAfter: dateString, percision: percisions[i + 1] });
+      message = validator.validate(moment(new Date(dateString)).subtract(1, percisions), { onOrAfter: dateString, percision: percisions[i + 1] });
       assert.equal(message, true);
     }
   }


### PR DESCRIPTION
This is a feature that has been a long time coming and requested by many power users. This allows a user to declare custom dependent keys on the validator level for custom validators. This will remove a lot of duplicate code and will also reduce the validation rules pojo. 

Since we only create the `ValidationsClass` once and only do it on first get of the `validations` CP, we can just create the CPs on init which gives access to the container. I made the API a static function so we dont have to actually instantiate the validator to access the dependents. I was hoping to get feedback before I work on documentation.

Another thing I can add is

```bash
ember g validator --with-dependents
```

which will create a validator file with the static function override via `reopenClass`.

Ping @stefanpenner @rwjblue @blimmer 😸 