### PR TITLE
Add import for getOwner to README example

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,6 +147,8 @@ export default Ember.Route.extend({
 
 ```javascript
 // routes/index.js
+import Ember from 'ember';
+const { getOwner } = Ember;
 
 import User from '../models/user';
 


### PR DESCRIPTION
Needed to specify that this function comes out of the Ember object in the README example docs.