### PR TITLE
Fix for data validator with format

### DIFF
--- a/addon/validators/date.js
+++ b/addon/validators/date.js
@@ -63,21 +63,21 @@ export default Base.extend({
     const format = options.format;
     const precision = options.precision;
     let { before, onOrBefore, after, onOrAfter } = options;
+    let date;
 
     if (options.allowBlank && isEmpty(value)) {
       return true;
-    }
-
-    let date = this._parseDate(value);
-
-    if (!date.isValid()) {
-      return this.createErrorMessage('date', value, options);
-    }
+    }  
 
     if (format) {
       date = this._parseDate(value, format, true);
       if (!date.isValid()) {
         return this.createErrorMessage('wrongDateFormat', value, options);
+      }
+    } else {
+      date = this._parseDate(value);
+      if (!date.isValid()) {
+        return this.createErrorMessage('date', value, options);
       }
     }
 

--- a/tests/unit/validators/date-test.js
+++ b/tests/unit/validators/date-test.js
@@ -61,13 +61,13 @@ test('valid input date format', function(assert) {
   assert.expect(2);
 
   options = {
-    format: 'M/D/YYYY'
+    format: 'DD/M/YYYY'
   };
 
-  message = validator.validate('1/1/15', assign({}, options));
-  assert.equal(message, 'This field must be in the format of M/D/YYYY');
+  message = validator.validate('27/3/15', assign({}, options));
+  assert.equal(message, 'This field must be in the format of DD/M/YYYY');
 
-  message = validator.validate('1/1/2015', assign({}, options));
+  message = validator.validate('27/3/2015', assign({}, options));
   assert.equal(message, true);
 });
 


### PR DESCRIPTION
The date validator is not working with format specified.
It always says invalid value.

It is first validated without the format, returns false, since Date() cannot parse it and then will return an error message and never tries with the format.
This fix skips the Date() check if format is specified
and fixes the data validator test to use a format that is not parsed by
Date()