### PR TITLE
Evaluate attrs options hash

### DIFF
--- a/addon/validations/factory.js
+++ b/addon/validations/factory.js
@@ -234,7 +234,6 @@ function createValidationsClass(inheritedValidationsClass, validations, owner) {
 
     validate,
     validateSync,
-    validateAttribute,
 
     init() {
       this._super(...arguments);
@@ -369,32 +368,6 @@ function createCPValidationFor(attribute, validations, owner) {
       content: flatten(validationResults)
     });
   })).readOnly();
-}
-
-function validateAttribute(attribute, value, options = {}) {
-  const model = get(this, 'model');
-  const validators = !isNone(model) ? getValidatorsFor(attribute, model) : [];
-
-  const validationResults = validators.map(validator => {
-    const opts = merge(validator.processOptions(), options);
-    const disabled = getWithDefault(opts, 'disabled', false);
-    let result = disabled ? true : validator.validate(value, opts, model, attribute);
-
-    return validationReturnValueHandler(attribute, result, model, validator);
-  });
-
-  const result = ValidationResultCollection.create({
-    attribute,
-    content: flatten(validationResults)
-  });
-
-  if(get(result, 'isAsync')) {
-    return get(result, '_promise').then(() => {
-      return result;
-    });
-  }
-
-  return result;
 }
 
 /**

--- a/addon/validations/factory.js
+++ b/addon/validations/factory.js
@@ -234,6 +234,7 @@ function createValidationsClass(inheritedValidationsClass, validations, owner) {
 
     validate,
     validateSync,
+    validateAttribute,
 
     init() {
       this._super(...arguments);
@@ -368,6 +369,32 @@ function createCPValidationFor(attribute, validations, owner) {
       content: flatten(validationResults)
     });
   })).readOnly();
+}
+
+function validateAttribute(attribute, value, options = {}) {
+  const model = get(this, 'model');
+  const validators = !isNone(model) ? getValidatorsFor(attribute, model) : [];
+
+  const validationResults = validators.map(validator => {
+    const opts = merge(validator.processOptions(), options);
+    const disabled = getWithDefault(opts, 'disabled', false);
+    let result = disabled ? true : validator.validate(value, opts, model, attribute);
+
+    return validationReturnValueHandler(attribute, result, model, validator);
+  });
+
+  const result = ValidationResultCollection.create({
+    attribute,
+    content: flatten(validationResults)
+  });
+
+  if(get(result, 'isAsync')) {
+    return get(result, '_promise').then(() => {
+      return result;
+    });
+  }
+
+  return result;
 }
 
 /**

--- a/addon/validations/internal-result-object.js
+++ b/addon/validations/internal-result-object.js
@@ -30,6 +30,7 @@ export default Ember.Object.extend({
 
   attrValue: null,
   _promise: null,
+  _validator: null,
 
   init() {
     this._super(...arguments);

--- a/addon/validations/result.js
+++ b/addon/validations/result.js
@@ -135,7 +135,7 @@ export default Ember.Object.extend({
    * @type {Result}
    */
   _validations: computed('model', 'attribute', '_promise', function () {
-    return InternalResultObject.create(getProperties(this, ['model', 'attribute', '_promise']));
+    return InternalResultObject.create(getProperties(this, ['model', 'attribute', '_promise', '_validator']));
   }),
 
   init() {

--- a/addon/validators/base.js
+++ b/addon/validators/base.js
@@ -72,6 +72,14 @@ const Base = Ember.Object.extend({
    */
   _type: null,
 
+  /**
+   * Cached processed options
+   * @property _cachedOptions
+   * @private
+   * @type {Object}
+   */
+  _cachedOptions: null,
+
   init() {
     this._super(...arguments);
     const globalOptions = get(this, 'globalOptions');
@@ -131,6 +139,9 @@ const Base = Ember.Object.extend({
         options[key] = option.call(this, model, attribute);
       }
     });
+
+    // Cache the options so it can be accessed without triggering this method again
+    set(this, '_cachedOptions', assign({}, options));
 
     return options;
   },


### PR DESCRIPTION
The options hash (`model.get('validations.attrs.username.options')`) is currently useless when a validator options is a function. This fixes that by having it contain the latest cached options. 

Resolves offirgolan/ember-bootstrap-cp-validations#4

