### PR TITLE
Allow computed properties in validator options

### DIFF
--- a/addon/validators/alias.js
+++ b/addon/validators/alias.js
@@ -77,7 +77,7 @@ const Alias = Base.extend({
 
 Alias.reopenClass({
   getDependentsFor(attribute, options) {
-    const alias = typeof options === 'string' ? options : options.alias;
+    const alias = typeof options === 'string' ? options : get(options, 'alias');
     return [ `${alias}.messages.[]`, `${alias}.isTruelyValid` ];
   }
 });

--- a/addon/validators/base.js
+++ b/addon/validators/base.js
@@ -10,6 +10,7 @@ import { unwrapString } from 'ember-cp-validations/utils/utils';
 
 const {
   get,
+  getWithDefault,
   set,
   isNone
 } = Ember;
@@ -115,7 +116,7 @@ const Base = Ember.Object.extend({
 
     // Overwrite the validator's value method if it exists in the options and remove it since
     // there is no need for it to be passed around
-    this.value = builtOptions.value || this.value;
+    this.value = getWithDefault(builtOptions, 'value', this.value);
     delete builtOptions.value;
 
     return builtOptions;
@@ -224,7 +225,7 @@ const Base = Ember.Object.extend({
    */
   createErrorMessage(type, value, options = {}) {
     const messages = this.get('errorMessages');
-    let message = unwrapString(options.message);
+    let message = unwrapString(get(options, 'message'));
 
     options.description = messages.getDescriptionFor(get(this, 'attribute'), options);
 

--- a/addon/validators/collection.js
+++ b/addon/validators/collection.js
@@ -7,6 +7,7 @@ import Ember from 'ember';
 import Base from 'ember-cp-validations/validators/base';
 
 const {
+  get,
   isArray
 } = Ember;
 
@@ -72,7 +73,7 @@ const Collection = Base.extend({
 
 Collection.reopenClass({
   getDependentsFor(attribute, options) {
-    return (options === true || options.collection === true) ? [ `_model.${attribute}.[]` ] : [];
+    return (options === true || get(options, 'collection') === true) ? [ `_model.${attribute}.[]` ] : [];
   }
 });
 

--- a/addon/validators/confirmation.js
+++ b/addon/validators/confirmation.js
@@ -35,7 +35,7 @@ const {
  */
 const Confirmation = Base.extend({
   validate(value, options, model) {
-    if (!isNone(options.on) && !isEqual(value, get(model, options.on))) {
+    if (!isNone(get(options, 'on')) && !isEqual(value, get(model, get(options, 'on')))) {
       return this.createErrorMessage('confirmation', value, options);
     }
 
@@ -45,7 +45,7 @@ const Confirmation = Base.extend({
 
 Confirmation.reopenClass({
   getDependentsFor(attribute, options) {
-    return options.on ? [ `_model.${options.on}` ] : [];
+    return get(options, 'on') ? [ `_model.${options.on}` ] : [];
   }
 });
 

--- a/addon/validators/date.js
+++ b/addon/validators/date.js
@@ -13,8 +13,12 @@ if (typeof moment === 'undefined') {
 }
 
 const {
+  get,
+  getWithDefault,
+  getProperties,
   isNone,
-  isEmpty
+  isEmpty,
+  set
 } = Ember;
 
 /**
@@ -59,15 +63,15 @@ export default Base.extend({
   },
 
   validate(value, options) {
-    const errorFormat = options.errorFormat || 'MMM Do, YYYY';
-    const format = options.format;
-    const precision = options.precision;
-    let { before, onOrBefore, after, onOrAfter } = options;
+    const errorFormat = getWithDefault(options, 'errorFormat', 'MMM Do, YYYY');
+    const format = get(options, 'format');
+    const precision = get(options, 'precision');
+    let { before, onOrBefore, after, onOrAfter } = getProperties(options, ['before', 'onOrBefore', 'after', 'onOrAfter']);
     let date;
 
-    if (options.allowBlank && isEmpty(value)) {
+    if (get(options, 'allowBlank') && isEmpty(value)) {
       return true;
-    }  
+    }
 
     if (format) {
       date = this._parseDate(value, format, true);
@@ -84,7 +88,7 @@ export default Base.extend({
     if (before) {
       before = this._parseDate(before, format);
       if (!date.isBefore(before, precision)) {
-        options.before = before.format(errorFormat);
+        set(options, 'before', before.format(errorFormat));
         return this.createErrorMessage('before', value, options);
       }
     }
@@ -92,7 +96,7 @@ export default Base.extend({
     if (onOrBefore) {
       onOrBefore = this._parseDate(onOrBefore, format);
       if (!date.isSameOrBefore(onOrBefore, precision))  {
-        options.onOrBefore = onOrBefore.format(errorFormat);
+        set(options, 'onOrBefore', onOrBefore.format(errorFormat));
         return this.createErrorMessage('onOrBefore', value, options);
       }
     }
@@ -100,7 +104,7 @@ export default Base.extend({
     if (after) {
       after = this._parseDate(after, format);
       if (!date.isAfter(after, precision)) {
-        options.after = after.format(errorFormat);
+        set(options, 'after', after.format(errorFormat));
         return this.createErrorMessage('after', value, options);
       }
     }
@@ -108,7 +112,7 @@ export default Base.extend({
     if (onOrAfter) {
       onOrAfter = this._parseDate(onOrAfter, format);
       if (!date.isSameOrAfter(onOrAfter, precision)) {
-        options.onOrAfter = onOrAfter.format(errorFormat);
+        set(options, 'onOrAfter', onOrAfter.format(errorFormat));
         return this.createErrorMessage('onOrAfter', value, options);
       }
     }

--- a/addon/validators/dependent.js
+++ b/addon/validators/dependent.js
@@ -7,7 +7,9 @@ import Ember from 'ember';
 import Base from 'ember-cp-validations/validators/base';
 
 const {
+  A,
   get,
+  getWithDefault,
   isNone,
   isEmpty
 } = Ember;
@@ -36,15 +38,15 @@ const Dependent = Base.extend({
       return true;
     }
 
-    if (options.allowBlank && isEmpty(value)) {
+    if (get(options, 'allowBlank') && isEmpty(value)) {
       return true;
     }
 
-    if (isEmpty(options.on)) {
+    if (isEmpty(get(options, 'on'))) {
       return true;
     }
 
-    const dependentValidations = options.on.map(dependent => get(model, `validations.attrs.${dependent}`));
+    const dependentValidations = getWithDefault(options, 'on', A()).map(dependent => get(model, `validations.attrs.${dependent}`));
 
     if (!isEmpty(dependentValidations.filter(v => !get(v, 'isTruelyValid')))) {
       return this.createErrorMessage('invalid', value, options);
@@ -56,7 +58,7 @@ const Dependent = Base.extend({
 
 Dependent.reopenClass({
   getDependentsFor(attribute, options) {
-    const dependents = options.on;
+    const dependents = get(options, 'on');
 
     if (!isEmpty(dependents)) {
       return dependents.map(dependent => `${dependent}.isTruelyValid`);

--- a/addon/validators/exclusion.js
+++ b/addon/validators/exclusion.js
@@ -7,6 +7,7 @@ import Ember from 'ember';
 import Base from 'ember-cp-validations/validators/base';
 
 const {
+  get,
   typeOf,
   isEmpty
 } = Ember;
@@ -35,14 +36,14 @@ const {
  */
 export default Base.extend({
   validate(value, options) {
-    const array = options.in;
-    const range = options.range;
+    const array = get(options, 'in');
+    const range = get(options, 'range');
 
     if (isEmpty(Object.keys(options))) {
       return true;
     }
 
-    if (options.allowBlank && isEmpty(value)) {
+    if (get(options, 'allowBlank') && isEmpty(value)) {
       return true;
     }
 

--- a/addon/validators/format.js
+++ b/addon/validators/format.js
@@ -71,8 +71,8 @@ export default Base.extend({
   buildOptions(options = {}, defaultOptions = {}, globalOptions = {}) {
     const regularExpressions = get(this, 'regularExpressions');
 
-    if (options.type && !isNone(regularExpressions[options.type]) && isNone(options.regex)) {
-      options.regex = regularExpressions[options.type];
+    if (options.type && !isNone(regularExpressions[get(options, 'type')]) && isNone(get(options, 'regex'))) {
+      options.regex = regularExpressions[get(options, 'type')];
     }
 
     return this._super(options, defaultOptions, globalOptions);
@@ -83,13 +83,13 @@ export default Base.extend({
       return true;
     }
 
-    if (options.allowBlank && isEmpty(value)) {
+    if (get(options, 'allowBlank') && isEmpty(value)) {
       return true;
     }
 
-    if (options.regex && !options.regex.test(value)) {
-      if (options.type) {
-        return this.createErrorMessage(options.type, value, options);
+    if (get(options, 'regex') && !get(options, 'regex').test(value)) {
+      if (get(options, 'type')) {
+        return this.createErrorMessage(get(options, 'type'), value, options);
       }
       return this.createErrorMessage('invalid', value, options);
     }

--- a/addon/validators/inclusion.js
+++ b/addon/validators/inclusion.js
@@ -7,6 +7,7 @@ import Ember from 'ember';
 import Base from 'ember-cp-validations/validators/base';
 
 const {
+  get,
   typeOf,
   isEmpty
 } = Ember;
@@ -51,14 +52,14 @@ const {
  */
 export default Base.extend({
   validate(value, options) {
-    const array = options.in;
-    const range = options.range;
+    const array = get(options, 'in');
+    const range = get(options, 'range');
 
     if (isEmpty(Object.keys(options))) {
       return true;
     }
 
-    if (options.allowBlank && isEmpty(value)) {
+    if (get(options, 'allowBlank') && isEmpty(value)) {
       return true;
     }
 

--- a/addon/validators/length.js
+++ b/addon/validators/length.js
@@ -48,7 +48,7 @@ export default Base.extend({
    * @return {Object}
    */
   buildOptions(options = {}, defaultOptions = {}, globalOptions = {}) {
-    options.allowNone = isNone(options.allowNone) ? true : options.allowNone;
+    options.allowNone = isNone(get(options, 'allowNone')) ? true : get(options, 'allowNone');
 
     return this._super(options, defaultOptions, globalOptions);
   },
@@ -59,22 +59,22 @@ export default Base.extend({
     }
 
     if (isNone(value)) {
-      return options.allowNone ? true : this.createErrorMessage('invalid', value, options);
+      return get(options, 'allowNone') ? true : this.createErrorMessage('invalid', value, options);
     }
 
-    if (options.allowBlank && isEmpty(value)) {
+    if (get(options, 'allowBlank') && isEmpty(value)) {
       return true;
     }
 
-    if (!isNone(options.is) && options.is !== get(value, 'length')) {
+    if (!isNone(get(options, 'is')) && get(options, 'is') !== get(value, 'length')) {
       return this.createErrorMessage('wrongLength', value, options);
     }
 
-    if (!isNone(options.min) && options.min > get(value, 'length')) {
+    if (!isNone(get(options, 'min')) && get(options, 'min') > get(value, 'length')) {
       return this.createErrorMessage('tooShort', value, options);
     }
 
-    if (!isNone(options.max) && options.max < get(value, 'length')) {
+    if (!isNone(get(options, 'max')) && get(options, 'max') < get(value, 'length')) {
       return this.createErrorMessage('tooLong', value, options);
     }
 

--- a/addon/validators/messages.js
+++ b/addon/validators/messages.js
@@ -56,7 +56,7 @@ export default Ember.Object.extend({
    * @return {String}
    */
   getDescriptionFor(attribute, options = {}) {
-    return options.description || get(this, 'defaultDescription');
+    return get(options, 'description') || get(this, 'defaultDescription');
   },
 
   /**

--- a/addon/validators/number.js
+++ b/addon/validators/number.js
@@ -7,6 +7,7 @@ import Ember from 'ember';
 import Base from 'ember-cp-validations/validators/base';
 
 const {
+  get,
   isEmpty
 } = Ember;
 
@@ -46,11 +47,11 @@ export default Base.extend({
     const numValue = Number(value);
     const optionKeys = Object.keys(options);
 
-    if (options.allowBlank && isEmpty(value)) {
+    if (get(options, 'allowBlank') && isEmpty(value)) {
       return true;
     }
 
-    if (typeof value === 'string' && (isEmpty(value) || !options.allowString)) {
+    if (typeof value === 'string' && (isEmpty(value) || !get(options, 'allowString'))) {
       return this.createErrorMessage('notANumber', value, options);
     }
 
@@ -58,7 +59,7 @@ export default Base.extend({
       return this.createErrorMessage('notANumber', value, options);
     }
 
-    if (options.integer && !this.isInteger(numValue)) {
+    if (get(options, 'integer') && !this.isInteger(numValue)) {
       return this.createErrorMessage('notAnInteger', value, options);
     }
 


### PR DESCRIPTION
It is currently not possible in ember-cp-validations to use computed properties as options for the validators (eg, to compute what should be the minLength of the field).

Simply by using `Ember.get(options, 'propertyName')` instead of `options.propertyName` in the validators, the implementor is allowed to benefit of computed properties.

I hope you'll like it!