### PR TITLE
[Feature] Computed Options 🔥

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,10 @@
 ---
 language: node_js
 node_js:
-  - "0.12"
+  - "4"
 
-sudo: false
+sudo: required
+dist: trusty
 
 cache:
   directories:
@@ -12,6 +13,11 @@ cache:
 addons:
   code_climate:
     repo_token: 32e4df25574ba02aacb75e6d34b9c667044984df279e20a208884d7e9e9d4a8d
+  apt:
+    sources:
+      - google-chrome
+    packages:
+      - google-chrome-stable
 
 env:
   - EMBER_TRY_SCENARIO=ember-1.11
@@ -32,10 +38,12 @@ matrix:
     - env: EMBER_TRY_SCENARIO=ember-canary
 
 before_install:
+  - export DISPLAY=:99.0
+  - sh -e /etc/init.d/xvfb start
   - export PATH=/usr/local/phantomjs-2.0.0/bin:$PATH
-  - "npm config set spin false"
-  - "npm install -g npm@^2"
-  - "npm install -g codeclimate-test-reporter"
+  - npm config set spin false
+  - npm install -g npm@^3
+  - npm install -g codeclimate-test-reporter
 
 install:
   - npm install -g bower

--- a/.travis.yml
+++ b/.travis.yml
@@ -40,7 +40,6 @@ matrix:
 before_install:
   - export DISPLAY=:99.0
   - sh -e /etc/init.d/xvfb start
-  - export PATH=/usr/local/phantomjs-2.0.0/bin:$PATH
   - npm config set spin false
   - npm install -g npm@^3
   - npm install -g codeclimate-test-reporter

--- a/addon/validations/factory.js
+++ b/addon/validations/factory.js
@@ -342,7 +342,7 @@ function createCPValidationFor(attribute, validations, owner) {
     const validators = !isNone(model) ? getValidatorsFor(attribute, model) : [];
 
     const validationResults = validators.map(validator => {
-      const options = validator.processOptions();
+      const options = get(validator, 'options').copy();
       const debounce = getWithDefault(options, 'debounce', 0);
       const disabled = getWithDefault(options, 'disabled', false);
       let value;
@@ -441,8 +441,22 @@ function getCPDependentKeysFor(attribute, validations, owner) {
       getWithDefault(validation, 'globalOptions.dependentKeys', [])
     );
 
+    // Process dependentKeys from the CPs
+    const cpDependents = Object.keys(options).reduce((arr, key) => {
+      let option = options[key];
+
+      if(typeof option === 'object' && get(option, 'isDescriptor')) {
+        return arr.concat(get(option, '_dependentKeys').map(d => {
+          return d.split('.')[0] === 'model' ? '_' + d : d;
+        }));
+      }
+
+      return arr;
+    }, []);
+
     return baseDependents.concat(
       dependents,
+      cpDependents,
       specifiedDependents.map(d => `_model.${d}`)
     );
   });
@@ -465,7 +479,7 @@ function getCPDependentKeysFor(attribute, validations, owner) {
  * @param  {Function} resolve
  */
 function debouncedValidate(validator, model, attribute, resolve) {
-  const options = validator.processOptions();
+  const options = get(validator, 'options').copy();
   const value = validator.getValue();
 
   resolve(validator.validate(value, options, model, attribute));

--- a/addon/validations/factory.js
+++ b/addon/validations/factory.js
@@ -434,6 +434,7 @@ function getCPDependentKeysFor(attribute, validations, owner) {
     const Validator = type === 'function' ? BaseValidator : lookupValidator(owner, type);
     const baseDependents = BaseValidator.getDependentsFor(attribute, options) || [];
     const dependents = Validator.getDependentsFor(attribute, options) || [];
+    let cpDependents = [];
 
     const specifiedDependents = [].concat(
       getWithDefault(options, 'dependentKeys', []),
@@ -442,19 +443,21 @@ function getCPDependentKeysFor(attribute, validations, owner) {
     );
 
     // Process dependentKeys from the CPs
-    const cpDependents = Object.keys(options).reduce((arr, key) => {
-      let option = options[key];
+    if(options && typeof options === 'object') {
+      cpDependents = Object.keys(options).reduce((arr, key) => {
+        let option = options[key];
 
-      if(typeof option === 'object' && option.isDescriptor) {
-        let dependentKeys = option._dependentKeys || [];
+        if(typeof option === 'object' && option.isDescriptor) {
+          let dependentKeys = option._dependentKeys || [];
 
-        return arr.concat(dependentKeys.map(d => {
-          return d.split('.')[0] === 'model' ? '_' + d : d;
-        }));
-      }
+          return arr.concat(dependentKeys.map(d => {
+            return d.split('.')[0] === 'model' ? '_' + d : d;
+          }));
+        }
 
-      return arr;
-    }, []);
+        return arr;
+      }, []);
+    }
 
     return baseDependents.concat(
       dependents,

--- a/addon/validations/factory.js
+++ b/addon/validations/factory.js
@@ -445,8 +445,10 @@ function getCPDependentKeysFor(attribute, validations, owner) {
     const cpDependents = Object.keys(options).reduce((arr, key) => {
       let option = options[key];
 
-      if(typeof option === 'object' && get(option, 'isDescriptor')) {
-        return arr.concat(get(option, '_dependentKeys').map(d => {
+      if(typeof option === 'object' && option.isDescriptor) {
+        let dependentKeys = option._dependentKeys || [];
+
+        return arr.concat(dependentKeys.map(d => {
           return d.split('.')[0] === 'model' ? '_' + d : d;
         }));
       }

--- a/addon/validations/factory.js
+++ b/addon/validations/factory.js
@@ -439,19 +439,23 @@ function getCPDependentKeysFor(attribute, validations, owner) {
       getWithDefault(options, 'dependentKeys', []),
       getWithDefault(validation, 'defaultOptions.dependentKeys', []),
       getWithDefault(validation, 'globalOptions.dependentKeys', [])
-    );
+    ).map(d => {
+      return d.split('.')[0] === 'model' ? '_' + d : d;
+    });
 
     // Extract dependentKeys from option CPs
     const cpDependents = [].concat(
       extractOptionsDependentKeys(options),
       extractOptionsDependentKeys(get(validation, 'defaultOptions')),
       extractOptionsDependentKeys(get(validation, 'globalOptions'))
-    );
+    ).map(d => {
+      return d.split('.')[0] === 'model' ? '_' + d : d;
+    });
 
     return baseDependents.concat(
       dependents,
       cpDependents,
-      specifiedDependents.map(d => `_model.${d}`)
+      specifiedDependents
     );
   });
 
@@ -474,11 +478,7 @@ function extractOptionsDependentKeys(options) {
       let option = options[key];
 
       if(typeof option === 'object' && option.isDescriptor) {
-        let dependentKeys = option._dependentKeys || [];
-
-        return arr.concat(dependentKeys.map(d => {
-          return d.split('.')[0] === 'model' ? '_' + d : d;
-        }));
+        return arr.concat(option._dependentKeys || []);
       }
 
       return arr;

--- a/addon/validations/result-collection.js
+++ b/addon/validations/result-collection.js
@@ -18,7 +18,6 @@ const {
   A: emberArray
 } = Ember;
 
-const assign = Ember.assign || Ember.merge;
 const A = emberArray();
 
 function callable(method) {
@@ -314,15 +313,13 @@ export default Ember.Object.extend({
    * @private
    */
   _groupValidatorOptions() {
-    const validators = get(this, 'content').getEach('_validator');
-
-    return validators.reduce((options, v) => {
+    return get(this, '_contentValidators').reduce((options, v) => {
       if (isNone(v) || isNone(get(v, '_type'))) {
         return options;
       }
 
       const type = get(v, '_type');
-      const vOpts = assign({}, get(v, '_cachedOptions'));
+      const vOpts = get(v, 'options').copy();
 
       if (options[type]) {
         if (isArray(options[type])) {

--- a/addon/validations/result-collection.js
+++ b/addon/validations/result-collection.js
@@ -270,7 +270,7 @@ export default Ember.Object.extend({
    * @readOnly
    * @type {Ember.ComputedProperty | Object}
    */
-  options: computed('_contentValidators.[]', '_contentValidators.@each._cachedOptions', function () {
+  options: computed('_contentValidators.[]', '_contentValidators.@each.options', function () {
     return this._groupValidatorOptions();
   }),
 

--- a/addon/validators/alias.js
+++ b/addon/validators/alias.js
@@ -77,7 +77,7 @@ const Alias = Base.extend({
 
 Alias.reopenClass({
   getDependentsFor(attribute, options) {
-    const alias = typeof options === 'string' ? options : options.alias;
+    const alias = typeof options === 'string' ? options : get(options, 'alias');
     return [ `${alias}.messages.[]`, `${alias}.isTruelyValid` ];
   }
 });

--- a/addon/validators/alias.js
+++ b/addon/validators/alias.js
@@ -78,6 +78,9 @@ const Alias = Base.extend({
 Alias.reopenClass({
   getDependentsFor(attribute, options) {
     const alias = typeof options === 'string' ? options : get(options, 'alias');
+
+    assert(`[ember-cp-validations] [validator:alias] [${attribute}] 'alias' must be a string`, typeof alias === 'string');
+
     return [ `${alias}.messages.[]`, `${alias}.isTruelyValid` ];
   }
 });

--- a/addon/validators/alias.js
+++ b/addon/validators/alias.js
@@ -8,7 +8,9 @@ import Base from 'ember-cp-validations/validators/base';
 
 const {
   get,
-  isEmpty
+  assert,
+  isEmpty,
+  getProperties
 } = Ember;
 
 /**
@@ -62,12 +64,10 @@ const Alias = Base.extend({
     return this._super(opts, defaultOptions, globalOptions);
   },
 
-  validate(value, options, model) {
-    const { alias, firstMessageOnly } = options;
+  validate(value, options, model, attribute) {
+    const { alias, firstMessageOnly } = getProperties(options, ['alias', 'firstMessageOnly']);
 
-    if(isEmpty(alias)) {
-      return true;
-    }
+    assert(`[ember-cp-validations] [validator:alias] [${attribute}] option 'alias' is required`, !isEmpty(alias));
 
     const aliasValidation = get(model, `validations.attrs.${alias}`);
 

--- a/addon/validators/base.js
+++ b/addon/validators/base.js
@@ -73,14 +73,6 @@ const Base = Ember.Object.extend({
    */
   _type: null,
 
-  /**
-   * Cached processed options
-   * @property _cachedOptions
-   * @private
-   * @type {Object}
-   */
-  _cachedOptions: null,
-
   init() {
     this._super(...arguments);
     const globalOptions = get(this, 'globalOptions');
@@ -135,6 +127,8 @@ const Base = Ember.Object.extend({
       }
     });
 
+    // Options object should be frozen since it should never be modified.
+    // Any modifications should be done on a copy
     return Object.freeze(OptionsClass.create());
   },
 

--- a/addon/validators/base.js
+++ b/addon/validators/base.js
@@ -69,7 +69,7 @@ const Base = Ember.Object.extend({
    * @property isWarning
    * @type {Boolean}
    */
-  isWarning: computed.bool('_cachedOptions.isWarning').readOnly(),
+  isWarning: computed.bool('options.isWarning').readOnly(),
 
   /**
    * Validator type

--- a/addon/validators/base.js
+++ b/addon/validators/base.js
@@ -11,7 +11,8 @@ import { unwrapString } from 'ember-cp-validations/utils/utils';
 const {
   get,
   set,
-  isNone
+  isNone,
+  computed
 } = Ember;
 
 const assign = Ember.assign || Ember.merge;
@@ -118,32 +119,23 @@ const Base = Ember.Object.extend({
     this.value = builtOptions.value || this.value;
     delete builtOptions.value;
 
-    return builtOptions;
-  },
+    const OptionsClass = Ember.Object.extend(builtOptions, {
+      model: computed(() => get(this, 'model')).readOnly(),
+      attribute: computed(() => get(this, 'attribute')).readOnly(),
 
-  /**
-   * Creates a new object and calls any option property that is a function with the validator context.
-   * This method is called right before `validate` and the returned object gets passed into the validate method as its options
-   * @method processOptions
-   * @return {Object}
-   */
-  processOptions() {
-    const options = assign({}, get(this, 'options') || {});
-    const model = get(this, 'model');
-    const attribute = get(this, 'attribute');
+      copy(deep) {
+        if(deep) {
+          return OptionsClass.create();
+        }
 
-    Object.keys(options).forEach(key => {
-      const option = options[key];
-
-      if (typeof option === 'function' && key !== 'message') {
-        options[key] = option.call(this, model, attribute);
+        return Ember.Object.create(Object.keys(builtOptions).reduce((obj, o) => {
+          obj[o] = get(this, o);
+          return obj;
+        }, {}));
       }
     });
 
-    // Cache the options so it can be accessed without triggering this method again
-    set(this, '_cachedOptions', assign({}, options));
-
-    return options;
+    return OptionsClass.create();
   },
 
   /**
@@ -201,8 +193,8 @@ const Base = Ember.Object.extend({
    * validate(value, options) {
    *   var exists = false;
    *
-   *   options.description = 'Username';
-   *   options.username = value;
+   *   get(options, 'description') = 'Username';
+   *   get(options, 'username') = value;
    *
    *   // check with server if username exists...
    *
@@ -224,9 +216,9 @@ const Base = Ember.Object.extend({
    */
   createErrorMessage(type, value, options = {}) {
     const messages = this.get('errorMessages');
-    let message = unwrapString(options.message);
+    let message = unwrapString(get(options, 'message'));
 
-    options.description = messages.getDescriptionFor(get(this, 'attribute'), options);
+    set(options, 'description', messages.getDescriptionFor(get(this, 'attribute'), options));
 
     if (message) {
       if (typeof message === 'string') {
@@ -312,7 +304,7 @@ export default Base;
  *         let message = `The username '${value}' already exists.`;
  *         let meta = user.get('meta');
  *
- *         if(options.showSuggestions && meta && meta.suggestions) {
+ *         if(get(options, 'showSuggestions') && meta && meta.suggestions) {
  *           message += "What about one of the these: " + meta.suggestions.join(', ');
  *         }
  *         return message;
@@ -416,7 +408,7 @@ export default Base;
  * ```javascript
  * // Example
  * validator(function(value, options, model, attribute) {
- *   return value === options.username ? true : `must be ${options.username}`;
+ *   return value === get(options, 'username') ? true : `must be ${get(options, 'username')}`;
  * } , {
  *   username: 'John' // Any options can be passed here
  * })

--- a/addon/validators/base.js
+++ b/addon/validators/base.js
@@ -135,7 +135,7 @@ const Base = Ember.Object.extend({
       }
     });
 
-    return OptionsClass.create();
+    return Object.freeze(OptionsClass.create());
   },
 
   /**

--- a/addon/validators/base.js
+++ b/addon/validators/base.js
@@ -127,9 +127,7 @@ const Base = Ember.Object.extend({
       }
     });
 
-    // Options object should be frozen since it should never be modified.
-    // Any modifications should be done on a copy
-    return Object.freeze(OptionsClass.create());
+    return OptionsClass.create();
   },
 
   /**

--- a/addon/validators/collection.js
+++ b/addon/validators/collection.js
@@ -7,6 +7,7 @@ import Ember from 'ember';
 import Base from 'ember-cp-validations/validators/base';
 
 const {
+  get,
   isArray
 } = Ember;
 
@@ -58,11 +59,11 @@ const Collection = Base.extend({
   },
 
   validate(value, options) {
-    if (options.collection === true && !isArray(value)) {
+    if (get(options, 'collection') === true && !isArray(value)) {
       return this.createErrorMessage('collection', value, options);
     }
 
-    if (options.collection === false && isArray(value)) {
+    if (get(options, 'collection') === false && isArray(value)) {
       return this.createErrorMessage('singular', value, options);
     }
 
@@ -72,7 +73,7 @@ const Collection = Base.extend({
 
 Collection.reopenClass({
   getDependentsFor(attribute, options) {
-    return (options === true || options.collection === true) ? [ `_model.${attribute}.[]` ] : [];
+    return (options === true || get(options, 'collection') === true) ? [ `_model.${attribute}.[]` ] : [];
   }
 });
 

--- a/addon/validators/collection.js
+++ b/addon/validators/collection.js
@@ -59,11 +59,13 @@ const Collection = Base.extend({
   },
 
   validate(value, options) {
-    if (get(options, 'collection') === true && !isArray(value)) {
+    const isCollection = get(options, 'collection');
+
+    if (isCollection === true && !isArray(value)) {
       return this.createErrorMessage('collection', value, options);
     }
 
-    if (get(options, 'collection') === false && isArray(value)) {
+    if (isCollection === false && isArray(value)) {
       return this.createErrorMessage('singular', value, options);
     }
 

--- a/addon/validators/confirmation.js
+++ b/addon/validators/confirmation.js
@@ -8,8 +8,9 @@ import Base from 'ember-cp-validations/validators/base';
 
 const {
   get,
+  assert,
   isEqual,
-  isNone
+  isEmpty,
 } = Ember;
 
 /**
@@ -34,8 +35,12 @@ const {
  *  @extends Base
  */
 const Confirmation = Base.extend({
-  validate(value, options, model) {
-    if (!isNone(get(options, 'on')) && !isEqual(value, get(model, get(options, 'on')))) {
+  validate(value, options, model, attribute) {
+    const on = get(options, 'on');
+
+    assert(`[ember-cp-validations] [validator:confirmation] [${attribute}] option 'on' is required`, !isEmpty(on));
+
+    if (!isEqual(value, get(model, on))) {
       return this.createErrorMessage('confirmation', value, options);
     }
 

--- a/addon/validators/confirmation.js
+++ b/addon/validators/confirmation.js
@@ -35,7 +35,7 @@ const {
  */
 const Confirmation = Base.extend({
   validate(value, options, model) {
-    if (!isNone(options.on) && !isEqual(value, get(model, options.on))) {
+    if (!isNone(get(options, 'on')) && !isEqual(value, get(model, get(options, 'on')))) {
       return this.createErrorMessage('confirmation', value, options);
     }
 
@@ -45,7 +45,7 @@ const Confirmation = Base.extend({
 
 Confirmation.reopenClass({
   getDependentsFor(attribute, options) {
-    return options.on ? [ `_model.${options.on}` ] : [];
+    return get(options, 'on') ? [ `_model.${get(options, 'on')}` ] : [];
   }
 });
 

--- a/addon/validators/confirmation.js
+++ b/addon/validators/confirmation.js
@@ -50,7 +50,11 @@ const Confirmation = Base.extend({
 
 Confirmation.reopenClass({
   getDependentsFor(attribute, options) {
-    return get(options, 'on') ? [ `_model.${get(options, 'on')}` ] : [];
+    const on = get(options, 'on');
+
+    assert(`[ember-cp-validations] [validator:confirmation] [${attribute}] 'on' must be a string`, typeof on === 'string');
+
+    return on ? [ `_model.${on}` ] : [];
   }
 });
 

--- a/addon/validators/date.js
+++ b/addon/validators/date.js
@@ -13,8 +13,12 @@ if (typeof moment === 'undefined') {
 }
 
 const {
+  get,
+  getWithDefault,
+  getProperties,
   isNone,
-  isEmpty
+  isEmpty,
+  set
 } = Ember;
 
 /**
@@ -59,15 +63,15 @@ export default Base.extend({
   },
 
   validate(value, options) {
-    const errorFormat = options.errorFormat || 'MMM Do, YYYY';
-    const format = options.format;
-    const precision = options.precision;
-    let { before, onOrBefore, after, onOrAfter } = options;
+    const errorFormat = getWithDefault(options, 'errorFormat', 'MMM Do, YYYY');
+    const format = get(options, 'format');
+    const precision = get(options, 'precision');
+    let { before, onOrBefore, after, onOrAfter } = getProperties(options, ['before', 'onOrBefore', 'after', 'onOrAfter']);
     let date;
 
-    if (options.allowBlank && isEmpty(value)) {
+    if (get(options, 'allowBlank') && isEmpty(value)) {
       return true;
-    }  
+    }
 
     if (format) {
       date = this._parseDate(value, format, true);
@@ -84,7 +88,7 @@ export default Base.extend({
     if (before) {
       before = this._parseDate(before, format);
       if (!date.isBefore(before, precision)) {
-        options.before = before.format(errorFormat);
+        set(options, 'before', before.format(errorFormat));
         return this.createErrorMessage('before', value, options);
       }
     }
@@ -92,7 +96,7 @@ export default Base.extend({
     if (onOrBefore) {
       onOrBefore = this._parseDate(onOrBefore, format);
       if (!date.isSameOrBefore(onOrBefore, precision))  {
-        options.onOrBefore = onOrBefore.format(errorFormat);
+        set(options, 'onOrBefore', onOrBefore.format(errorFormat));
         return this.createErrorMessage('onOrBefore', value, options);
       }
     }
@@ -100,7 +104,7 @@ export default Base.extend({
     if (after) {
       after = this._parseDate(after, format);
       if (!date.isAfter(after, precision)) {
-        options.after = after.format(errorFormat);
+        set(options, 'after', after.format(errorFormat));
         return this.createErrorMessage('after', value, options);
       }
     }
@@ -108,7 +112,7 @@ export default Base.extend({
     if (onOrAfter) {
       onOrAfter = this._parseDate(onOrAfter, format);
       if (!date.isSameOrAfter(onOrAfter, precision)) {
-        options.onOrAfter = onOrAfter.format(errorFormat);
+        set(options, 'onOrAfter', onOrAfter.format(errorFormat));
         return this.createErrorMessage('onOrAfter', value, options);
       }
     }

--- a/addon/validators/date.js
+++ b/addon/validators/date.js
@@ -13,7 +13,6 @@ if (typeof moment === 'undefined') {
 }
 
 const {
-  get,
   getWithDefault,
   getProperties,
   isNone,
@@ -64,12 +63,11 @@ export default Base.extend({
 
   validate(value, options) {
     const errorFormat = getWithDefault(options, 'errorFormat', 'MMM Do, YYYY');
-    const format = get(options, 'format');
-    const precision = get(options, 'precision');
+    const { format, precision, allowBlank } = getProperties(options, ['format', 'precision', 'allowBlank']);
     let { before, onOrBefore, after, onOrAfter } = getProperties(options, ['before', 'onOrBefore', 'after', 'onOrAfter']);
     let date;
 
-    if (get(options, 'allowBlank') && isEmpty(value)) {
+    if (allowBlank && isEmpty(value)) {
       return true;
     }
 

--- a/addon/validators/dependent.js
+++ b/addon/validators/dependent.js
@@ -7,7 +7,9 @@ import Ember from 'ember';
 import Base from 'ember-cp-validations/validators/base';
 
 const {
+  A,
   get,
+  getWithDefault,
   isNone,
   isEmpty
 } = Ember;
@@ -36,15 +38,15 @@ const Dependent = Base.extend({
       return true;
     }
 
-    if (options.allowBlank && isEmpty(value)) {
+    if (get(options, 'allowBlank') && isEmpty(value)) {
       return true;
     }
 
-    if (isEmpty(options.on)) {
+    if (isEmpty(get(options, 'on'))) {
       return true;
     }
 
-    const dependentValidations = options.on.map(dependent => get(model, `validations.attrs.${dependent}`));
+    const dependentValidations = getWithDefault(options, 'on', A()).map(dependent => get(model, `validations.attrs.${dependent}`));
 
     if (!isEmpty(dependentValidations.filter(v => !get(v, 'isTruelyValid')))) {
       return this.createErrorMessage('invalid', value, options);
@@ -56,7 +58,7 @@ const Dependent = Base.extend({
 
 Dependent.reopenClass({
   getDependentsFor(attribute, options) {
-    const dependents = options.on;
+    const dependents = get(options, 'on');
 
     if (!isEmpty(dependents)) {
       return dependents.map(dependent => `${dependent}.isTruelyValid`);

--- a/addon/validators/dependent.js
+++ b/addon/validators/dependent.js
@@ -10,6 +10,8 @@ const {
   A,
   get,
   getWithDefault,
+  getProperties,
+  assert,
   isNone,
   isEmpty
 } = Ember;
@@ -33,16 +35,16 @@ const {
  *  @extends Base
  */
 const Dependent = Base.extend({
-  validate(value, options, model) {
-    if (isNone(options) || isNone(model) || isEmpty(Object.keys(options))) {
+  validate(value, options, model, attribute) {
+    const { on, allowBlank } = getProperties(options, ['on', 'allowBlank']);
+
+    assert(`[ember-cp-validations] [validator:dependent] [${attribute}] option 'on' is required`, !isEmpty(on));
+
+    if (isNone(model)) {
       return true;
     }
 
-    if (get(options, 'allowBlank') && isEmpty(value)) {
-      return true;
-    }
-
-    if (isEmpty(get(options, 'on'))) {
+    if (allowBlank && isEmpty(value)) {
       return true;
     }
 

--- a/addon/validators/dependent.js
+++ b/addon/validators/dependent.js
@@ -13,7 +13,8 @@ const {
   getProperties,
   assert,
   isNone,
-  isEmpty
+  isEmpty,
+  isArray
 } = Ember;
 
 /**
@@ -61,6 +62,8 @@ const Dependent = Base.extend({
 Dependent.reopenClass({
   getDependentsFor(attribute, options) {
     const dependents = get(options, 'on');
+
+    assert(`[ember-cp-validations] [validator:dependent] [${attribute}] 'on' must be an array`, isArray(dependents));
 
     if (!isEmpty(dependents)) {
       return dependents.map(dependent => `${dependent}.isTruelyValid`);

--- a/addon/validators/exclusion.js
+++ b/addon/validators/exclusion.js
@@ -7,6 +7,7 @@ import Ember from 'ember';
 import Base from 'ember-cp-validations/validators/base';
 
 const {
+  get,
   typeOf,
   isEmpty
 } = Ember;
@@ -35,14 +36,14 @@ const {
  */
 export default Base.extend({
   validate(value, options) {
-    const array = options.in;
-    const range = options.range;
+    const array = get(options, 'in');
+    const range = get(options, 'range');
 
     if (isEmpty(Object.keys(options))) {
       return true;
     }
 
-    if (options.allowBlank && isEmpty(value)) {
+    if (get(options, 'allowBlank') && isEmpty(value)) {
       return true;
     }
 

--- a/addon/validators/exclusion.js
+++ b/addon/validators/exclusion.js
@@ -9,7 +9,9 @@ import Base from 'ember-cp-validations/validators/base';
 const {
   get,
   typeOf,
-  isEmpty
+  isEmpty,
+  assert,
+  getProperties
 } = Ember;
 
 /**
@@ -35,15 +37,13 @@ const {
  *  @extends Base
  */
 export default Base.extend({
-  validate(value, options) {
+  validate(value, options, model, attribute) {
     const array = get(options, 'in');
-    const range = get(options, 'range');
+    const { range, allowBlank } = getProperties(options, ['range', 'allowBlank']);
 
-    if (isEmpty(Object.keys(options))) {
-      return true;
-    }
+    assert(`[ember-cp-validations] [validator:exclusion] [${attribute}] no options were passed in`, !isEmpty(Object.keys(options)));
 
-    if (get(options, 'allowBlank') && isEmpty(value)) {
+    if (allowBlank && isEmpty(value)) {
       return true;
     }
 

--- a/addon/validators/format.js
+++ b/addon/validators/format.js
@@ -10,7 +10,9 @@ import Base from 'ember-cp-validations/validators/base';
 const {
   get,
   isNone,
-  isEmpty
+  isEmpty,
+  assert,
+  getProperties
 } = Ember;
 
 /**
@@ -71,28 +73,26 @@ export default Base.extend({
    */
   buildOptions(options = {}, defaultOptions = {}, globalOptions = {}) {
     const regularExpressions = get(this, 'regularExpressions');
+    const { regex, type } = options;
 
-    if (options.type && !isNone(regularExpressions[get(options, 'type')]) && isNone(get(options, 'regex'))) {
-      options.regex = regularExpressions[get(options, 'type')];
+    if (type && !isNone(regularExpressions[type]) && isNone(regex)) {
+      options.regex = regularExpressions[type];
     }
 
     return this._super(options, defaultOptions, globalOptions);
   },
 
-  validate(value, options) {
-    if (isEmpty(Object.keys(options))) {
+  validate(value, options, model, attribute) {
+    const { regex, type, allowBlank } = getProperties(options, ['regex', 'type', 'allowBlank']);
+
+    assert(`[ember-cp-validations] [validator:format] [${attribute}] no options were passed in`, !isEmpty(Object.keys(options)));
+
+    if (allowBlank && isEmpty(value)) {
       return true;
     }
 
-    if (get(options, 'allowBlank') && isEmpty(value)) {
-      return true;
-    }
-
-    if (get(options, 'regex') && !get(options, 'regex').test(value)) {
-      if (get(options, 'type')) {
-        return this.createErrorMessage(get(options, 'type'), value, options);
-      }
-      return this.createErrorMessage('invalid', value, options);
+    if (regex && !regex.test(value)) {
+      return this.createErrorMessage(type || 'invalid', value, options);
     }
 
     return true;

--- a/addon/validators/format.js
+++ b/addon/validators/format.js
@@ -1,3 +1,4 @@
+
 /**
  * Copyright 2016, Yahoo! Inc.
  * Copyrights licensed under the New BSD License. See the accompanying LICENSE file for terms.
@@ -71,8 +72,8 @@ export default Base.extend({
   buildOptions(options = {}, defaultOptions = {}, globalOptions = {}) {
     const regularExpressions = get(this, 'regularExpressions');
 
-    if (options.type && !isNone(regularExpressions[options.type]) && isNone(options.regex)) {
-      options.regex = regularExpressions[options.type];
+    if (options.type && !isNone(regularExpressions[get(options, 'type')]) && isNone(get(options, 'regex'))) {
+      options.regex = regularExpressions[get(options, 'type')];
     }
 
     return this._super(options, defaultOptions, globalOptions);
@@ -83,13 +84,13 @@ export default Base.extend({
       return true;
     }
 
-    if (options.allowBlank && isEmpty(value)) {
+    if (get(options, 'allowBlank') && isEmpty(value)) {
       return true;
     }
 
-    if (options.regex && !options.regex.test(value)) {
-      if (options.type) {
-        return this.createErrorMessage(options.type, value, options);
+    if (get(options, 'regex') && !get(options, 'regex').test(value)) {
+      if (get(options, 'type')) {
+        return this.createErrorMessage(get(options, 'type'), value, options);
       }
       return this.createErrorMessage('invalid', value, options);
     }

--- a/addon/validators/inclusion.js
+++ b/addon/validators/inclusion.js
@@ -7,6 +7,7 @@ import Ember from 'ember';
 import Base from 'ember-cp-validations/validators/base';
 
 const {
+  get,
   typeOf,
   isEmpty
 } = Ember;
@@ -51,14 +52,14 @@ const {
  */
 export default Base.extend({
   validate(value, options) {
-    const array = options.in;
-    const range = options.range;
+    const array = get(options, 'in');
+    const range = get(options, 'range');
 
     if (isEmpty(Object.keys(options))) {
       return true;
     }
 
-    if (options.allowBlank && isEmpty(value)) {
+    if (get(options, 'allowBlank') && isEmpty(value)) {
       return true;
     }
 

--- a/addon/validators/inclusion.js
+++ b/addon/validators/inclusion.js
@@ -9,7 +9,9 @@ import Base from 'ember-cp-validations/validators/base';
 const {
   get,
   typeOf,
-  isEmpty
+  assert,
+  isEmpty,
+  getProperties
 } = Ember;
 
 /**
@@ -51,15 +53,13 @@ const {
  *  @extends Base
  */
 export default Base.extend({
-  validate(value, options) {
+  validate(value, options, model, attribute) {
     const array = get(options, 'in');
-    const range = get(options, 'range');
+    const { range, allowBlank } = getProperties(options, ['range', 'allowBlank']);
 
-    if (isEmpty(Object.keys(options))) {
-      return true;
-    }
+    assert(`[ember-cp-validations] [validator:inclusion] [${attribute}] no options were passed in`, !isEmpty(Object.keys(options)));
 
-    if (get(options, 'allowBlank') && isEmpty(value)) {
+    if (allowBlank && isEmpty(value)) {
       return true;
     }
 

--- a/addon/validators/length.js
+++ b/addon/validators/length.js
@@ -8,6 +8,7 @@ import Base from 'ember-cp-validations/validators/base';
 
 const {
   get,
+  assert,
   isNone,
   isEmpty,
   getProperties
@@ -54,8 +55,10 @@ export default Base.extend({
     return this._super(options, defaultOptions, globalOptions);
   },
 
-  validate(value, options) {
+  validate(value, options, model, attribute) {
     const { allowNone, allowBlank, is, min, max } = getProperties(options, [ 'allowNone', 'allowBlank', 'is', 'min', 'max' ]);
+
+    assert(`[ember-cp-validations] [validator:length] [${attribute}] no options were passed in`, !isEmpty(Object.keys(options)));
 
     if (isNone(value)) {
       return allowNone ? true : this.createErrorMessage('invalid', value, options);

--- a/addon/validators/length.js
+++ b/addon/validators/length.js
@@ -9,7 +9,8 @@ import Base from 'ember-cp-validations/validators/base';
 const {
   get,
   isNone,
-  isEmpty
+  isEmpty,
+  getProperties
 } = Ember;
 
 /**
@@ -48,33 +49,31 @@ export default Base.extend({
    * @return {Object}
    */
   buildOptions(options = {}, defaultOptions = {}, globalOptions = {}) {
-    options.allowNone = isNone(options.allowNone) ? true : options.allowNone;
+    options.allowNone = isNone(get(options, 'allowNone')) ? true : get(options, 'allowNone');
 
     return this._super(options, defaultOptions, globalOptions);
   },
 
   validate(value, options) {
-    if (isEmpty(Object.keys(options))) {
-      return true;
-    }
+    const { allowNone, allowBlank, is, min, max } = getProperties(options, [ 'allowNone', 'allowBlank', 'is', 'min', 'max' ]);
 
     if (isNone(value)) {
-      return options.allowNone ? true : this.createErrorMessage('invalid', value, options);
+      return allowNone ? true : this.createErrorMessage('invalid', value, options);
     }
 
-    if (options.allowBlank && isEmpty(value)) {
+    if (allowBlank && isEmpty(value)) {
       return true;
     }
 
-    if (!isNone(options.is) && options.is !== get(value, 'length')) {
+    if (!isNone(is) && is !== get(value, 'length')) {
       return this.createErrorMessage('wrongLength', value, options);
     }
 
-    if (!isNone(options.min) && options.min > get(value, 'length')) {
+    if (!isNone(min) && min > get(value, 'length')) {
       return this.createErrorMessage('tooShort', value, options);
     }
 
-    if (!isNone(options.max) && options.max < get(value, 'length')) {
+    if (!isNone(max) && max < get(value, 'length')) {
       return this.createErrorMessage('tooLong', value, options);
     }
 

--- a/addon/validators/messages.js
+++ b/addon/validators/messages.js
@@ -56,7 +56,7 @@ export default Ember.Object.extend({
    * @return {String}
    */
   getDescriptionFor(attribute, options = {}) {
-    return options.description || get(this, 'defaultDescription');
+    return get(options, 'description') || get(this, 'defaultDescription');
   },
 
   /**
@@ -83,7 +83,7 @@ export default Ember.Object.extend({
     if (isNone(m) || typeof m !== 'string') {
       m = get(this, 'invalid');
     }
-    return m.replace(get(this, '_regex'), (s, attr) => context[attr]);
+    return m.replace(get(this, '_regex'), (s, attr) => get(context, attr));
   },
 
   /**

--- a/addon/validators/number.js
+++ b/addon/validators/number.js
@@ -7,6 +7,7 @@ import Ember from 'ember';
 import Base from 'ember-cp-validations/validators/base';
 
 const {
+  get,
   isEmpty
 } = Ember;
 
@@ -46,11 +47,11 @@ export default Base.extend({
     const numValue = Number(value);
     const optionKeys = Object.keys(options);
 
-    if (options.allowBlank && isEmpty(value)) {
+    if (get(options, 'allowBlank') && isEmpty(value)) {
       return true;
     }
 
-    if (typeof value === 'string' && (isEmpty(value) || !options.allowString)) {
+    if (typeof value === 'string' && (isEmpty(value) || !get(options, 'allowString'))) {
       return this.createErrorMessage('notANumber', value, options);
     }
 
@@ -58,7 +59,7 @@ export default Base.extend({
       return this.createErrorMessage('notANumber', value, options);
     }
 
-    if (options.integer && !this.isInteger(numValue)) {
+    if (get(options, 'integer') && !this.isInteger(numValue)) {
       return this.createErrorMessage('notAnInteger', value, options);
     }
 

--- a/addon/validators/number.js
+++ b/addon/validators/number.js
@@ -8,7 +8,8 @@ import Base from 'ember-cp-validations/validators/base';
 
 const {
   get,
-  isEmpty
+  isEmpty,
+  getProperties
 } = Ember;
 
 /**
@@ -46,12 +47,13 @@ export default Base.extend({
   validate(value, options) {
     const numValue = Number(value);
     const optionKeys = Object.keys(options);
+    const { allowBlank, allowString, integer } = getProperties(options, ['allowBlank', 'allowString', 'integer']);
 
-    if (get(options, 'allowBlank') && isEmpty(value)) {
+    if (allowBlank && isEmpty(value)) {
       return true;
     }
 
-    if (typeof value === 'string' && (isEmpty(value) || !get(options, 'allowString'))) {
+    if (typeof value === 'string' && (isEmpty(value) || !allowString)) {
       return this.createErrorMessage('notANumber', value, options);
     }
 
@@ -59,7 +61,7 @@ export default Base.extend({
       return this.createErrorMessage('notANumber', value, options);
     }
 
-    if (get(options, 'integer') && !this.isInteger(numValue)) {
+    if (integer && !this.isInteger(numValue)) {
       return this.createErrorMessage('notAnInteger', value, options);
     }
 
@@ -76,7 +78,7 @@ export default Base.extend({
   },
 
   _validateType(type, options, value) {
-    const expected = options[type];
+    const expected = get(options, type);
     const actual = value;
 
     if (type === 'is' && actual !== expected) {

--- a/addon/validators/presence.js
+++ b/addon/validators/presence.js
@@ -8,8 +8,10 @@ import Base from 'ember-cp-validations/validators/base';
 
 const {
   get,
+  assert,
   isEmpty,
-  isPresent
+  isPresent,
+  getProperties
 } = Ember;
 
 /**
@@ -67,8 +69,10 @@ export default Base.extend({
     return this._super(opts, defaultOptions, globalOptions);
   },
 
-  validate(value, options) {
-    const { presence, ignoreBlank } = options;
+  validate(value, options, model, attribute) {
+    const { presence, ignoreBlank } = getProperties(options, ['presence', 'ignoreBlank']);
+
+    assert(`[ember-cp-validations] [validator:presence] [${attribute}] option 'presence' is required`, !isEmpty(presence));
 
     if (presence === true && !this._isPresent(value, ignoreBlank)) {
       return this.createErrorMessage('blank', value, options);

--- a/testem.js
+++ b/testem.js
@@ -5,10 +5,9 @@ module.exports = {
   "disable_watching": true,
   "phantomjs_debug_port": 9000,
   "launch_in_ci": [
-    "PhantomJS"
+    "Chrome"
   ],
   "launch_in_dev": [
-    "PhantomJS",
     "Chrome"
   ]
 };

--- a/tests/dummy/app/adapters/application.js
+++ b/tests/dummy/app/adapters/application.js
@@ -1,0 +1,4 @@
+import RESTAPIAdapter from 'ember-data/adapters/rest';
+
+export default RESTAPIAdapter.extend({
+});

--- a/tests/dummy/app/models/user-detail.js
+++ b/tests/dummy/app/models/user-detail.js
@@ -11,6 +11,10 @@ import {
 }
 from 'ember-cp-validations';
 
+const {
+  computed
+} = Ember;
+
 var attr = DS.attr;
 
 var Validations = buildValidations({
@@ -22,9 +26,9 @@ var Validations = buildValidations({
       validator('presence', true),
       validator('date', {
         before: 'now',
-        after() {
+        after: computed(function() {
           return moment().subtract(120, 'years').format('M/D/YYYY');
-        },
+        }).volatile(),
         format: 'M/D/YYYY',
         message: function(type, value, context) {
           if (type === 'before') {

--- a/tests/dummy/app/models/user.js
+++ b/tests/dummy/app/models/user.js
@@ -19,7 +19,7 @@ var Validations = buildValidations({
     validators: [
       validator('presence', true),
       validator('length', {
-        max: computed.alias('model.maxLength')
+        min: computed.alias('model.minLength')
       })
     ]
   },
@@ -60,5 +60,5 @@ export default DS.Model.extend(Validations, {
   'email': attr('string'),
   'details': DS.belongsTo('user-detail'),
 
-  maxLength: 5
+  minLength: 5
 });

--- a/tests/dummy/app/models/user.js
+++ b/tests/dummy/app/models/user.js
@@ -7,6 +7,10 @@ import Ember from 'ember';
 import DS from 'ember-data';
 import { validator, buildValidations } from 'ember-cp-validations';
 
+const {
+  computed
+} = Ember;
+
 var attr = DS.attr;
 
 var Validations = buildValidations({
@@ -15,7 +19,7 @@ var Validations = buildValidations({
     validators: [
       validator('presence', true),
       validator('length', {
-        max: 15
+        max: computed.alias('model.maxLength')
       })
     ]
   },
@@ -54,5 +58,7 @@ export default DS.Model.extend(Validations, {
   'username': attr('string'),
   'password': attr('string'),
   'email': attr('string'),
-  'details': DS.belongsTo('user-detail')
+  'details': DS.belongsTo('user-detail'),
+
+  maxLength: 5
 });

--- a/tests/integration/validations/factory-dependent-keys-test.js
+++ b/tests/integration/validations/factory-dependent-keys-test.js
@@ -66,7 +66,7 @@ test("custom dependent keys - simple", function(assert) {
       }
       return true;
     }, {
-      dependentKeys: ['firstName', 'lastName']
+      dependentKeys: ['model.firstName', 'model.lastName']
     })
   });
 
@@ -86,7 +86,7 @@ test("custom dependent keys - simple", function(assert) {
 test("custom dependent keys - default options", function(assert) {
   var Validations = buildValidations({
     fullName: {
-      dependentKeys: ['firstName'],
+      dependentKeys: ['model.firstName'],
       validators: [
         validator(function(value, options, model) {
           let firstName = model.get('firstName');
@@ -96,7 +96,7 @@ test("custom dependent keys - default options", function(assert) {
           }
           return true;
         }, {
-          dependentKeys: ['lastName']
+          dependentKeys: ['model.lastName']
         })
       ]
     }
@@ -118,7 +118,7 @@ test("custom dependent keys - default options", function(assert) {
 test("custom dependent keys - global options", function(assert) {
   var Validations = buildValidations({
     fullName: {
-      dependentKeys: ['firstName'],
+      dependentKeys: ['model.firstName'],
       validators: [
         validator(function(value, options, model) {
           let firstName = model.get('firstName');
@@ -129,12 +129,12 @@ test("custom dependent keys - global options", function(assert) {
           }
           return true;
         }, {
-          dependentKeys: ['lastName']
+          dependentKeys: ['model.lastName']
         })
       ]
     }
   }, {
-    dependentKeys: ['middleName']
+    dependentKeys: ['model.middleName']
   });
 
   var obj = setupObject(this, Ember.Object.extend(Validations));
@@ -165,7 +165,7 @@ test("custom dependent keys - nested object", function(assert) {
       }
       return true;
     }, {
-      dependentKeys: ['currPage', 'meta.pages.last']
+      dependentKeys: ['model.currPage', 'model.meta.pages.last']
     })
   });
 
@@ -203,7 +203,7 @@ test("custom dependent keys - array", function(assert) {
       }
       return true;
     }, {
-      dependentKeys: ['friends.[]']
+      dependentKeys: ['model.friends.[]']
     })
   });
 
@@ -242,7 +242,7 @@ test("custom dependent keys - array of objects", function(assert) {
       }
       return true;
     }, {
-      dependentKeys: ['friends.@each.name']
+      dependentKeys: ['model.friends.@each.name']
     })
   });
 

--- a/tests/integration/validations/factory-general-test.js
+++ b/tests/integration/validations/factory-general-test.js
@@ -7,7 +7,8 @@ import { validator, buildValidations } from 'ember-cp-validations';
 import { moduleFor, test } from 'ember-qunit';
 
 const {
-  run
+  run,
+  computed
 } = Ember;
 
 const Validators = {
@@ -267,7 +268,7 @@ test("global options", function(assert) {
   assert.ok(object.get('validations.attrs.firstName.isInvalid'));
 
   var v = object.get('validations._validators.firstName.0');
-  assert.deepEqual(v.get('options'), {
+  assert.deepEqual(v.get('options').getProperties(['message', 'description', 'allowNone', 'min', 'max']), {
     message: 'Global error message',
     description: 'Test field',
     allowNone: true,
@@ -297,9 +298,9 @@ test("debounced validations", function(assert) {
   var Validations = buildValidations({
     firstName: validator(Validators.presence),
     lastName: validator(Validators.presence, {
-      debounce() {
+      debounce: computed(function() {
         return initSetup ? 0 : 500; // Do not debounce on initial object creation
-      }
+      }).volatile()
     }),
   });
   var object = setupObject(this, Ember.Object.extend(Validations));
@@ -332,9 +333,9 @@ test("debounced validations should cleanup on object destroy", function(assert) 
     model.set('foo', 'bar');
     return Validators.presence(value, options, model, attr);
   }, {
-    debounce() {
-      return initSetup ? 0 : 500; // Do not debounce on initial object creation
-    }
+    debounce: computed(function() {
+      return initSetup ? 0 : 500;
+    }).volatile()
   });
 
   var Validations = buildValidations({
@@ -394,14 +395,11 @@ test("disabled validations - simple", function(assert) {
   assert.equal(object.get('validations.isValid'), true);
 });
 
-test("disabled validations - function with dependent key", function(assert) {
+test("disabled validations - cp with dependent key", function(assert) {
   var Validations = buildValidations({
     firstName: validator(Validators.presence),
     lastName: validator(Validators.presence, {
-      dependentKeys: ['validateLastName'],
-      disabled() {
-        return !this.get('model.validateLastName');
-      }
+      disabled: computed.not('model.validateLastName')
     })
   });
   var object = setupObject(this, Ember.Object.extend(Validations, {
@@ -475,20 +473,15 @@ test("attribute validation result options hash", function(assert) {
   assert.equal(options['function'][0].description, 'First Name');
 });
 
-test("attribute validation result options hash with functions", function(assert) {
-  assert.expect(5);
+test("attribute validation result options hash with cps", function(assert) {
   this.register('validator:length', LengthValidator);
 
   var Validations = buildValidations({
     firstName: {
       validators: [
         validator('length', {
-          dependentKeys: ['max'],
           min: 1,
-          max(model) {
-            assert.ok(true);
-            return model.get('max');
-          }
+          max: computed.readOnly('model.max')
         })
       ]
     }
@@ -498,9 +491,6 @@ test("attribute validation result options hash with functions", function(assert)
   assert.equal(options.length.max, 5);
 
   run(() => object.set('max', 3));
-
-  options = object.get('validations.attrs.firstName.options');
-  assert.equal(options.length.max, 3);
 
   options = object.get('validations.attrs.firstName.options');
   assert.equal(options.length.max, 3);

--- a/tests/unit/validators/base-test.js
+++ b/tests/unit/validators/base-test.js
@@ -51,6 +51,28 @@ test('buildOptions - does not overwrite options', function(assert) {
   assert.deepEqual(options.getProperties(['foo', 'bar']), { foo: 'a', bar: 'b'});
 });
 
+test('buildOptions - copy', function(assert) {
+  assert.expect(6);
+
+  options = validator.buildOptions({
+    foo: Ember.computed.alias('bar'),
+    bar: 'bar'
+  });
+
+  assert.ok(options instanceof Ember.Object);
+
+  let optionsCopy = options.copy();
+
+  assert.ok(optionsCopy instanceof Ember.Object);
+  assert.equal(optionsCopy.foo, 'bar');
+
+  optionsCopy = options.copy(true);
+
+  assert.ok(optionsCopy instanceof Ember.Object);
+  assert.ok(optionsCopy.foo.isDescriptor);
+  assert.equal(optionsCopy.get('foo'), 'bar');
+});
+
 test('createErrorMessage - message function', function(assert) {
   assert.expect(1);
 

--- a/tests/unit/validators/base-test.js
+++ b/tests/unit/validators/base-test.js
@@ -32,7 +32,7 @@ test('buildOptions - merge all options', function(assert) {
   };
 
   options = validator.buildOptions(options, defaultOptions);
-  assert.deepEqual(options, { foo: 'a', bar: 'b'});
+  assert.deepEqual(options.getProperties(['foo', 'bar']), { foo: 'a', bar: 'b'});
 });
 
 test('buildOptions - does not overwrite options', function(assert) {
@@ -48,23 +48,23 @@ test('buildOptions - does not overwrite options', function(assert) {
   };
 
   options = validator.buildOptions(options, defaultOptions);
-  assert.deepEqual(options, { foo: 'a', bar: 'b'});
+  assert.deepEqual(options.getProperties(['foo', 'bar']), { foo: 'a', bar: 'b'});
 });
 
-test('processOptions - calls functions', function(assert) {
-  assert.expect(2);
+test('buildOptions - returned options are frozen', function(assert) {
+  assert.expect(1);
 
   options = {
-    foo() { return 'a'; },
-    message() {
-      return "has some sort of error";
-    }
+    foo: 'a'
   };
 
-  validator.set('options', options);
-  options = validator.processOptions();
-  assert.equal(options.foo, 'a');
-  assert.equal(typeof options.message, 'function', 'message function should only be called by createErrorMessage');
+  options = validator.buildOptions(options);
+
+  try {
+    options.set('foo', 'bar');
+  } catch (e) {
+    assert.ok(true);
+  }
 });
 
 test('createErrorMessage - message function', function(assert) {
@@ -113,7 +113,7 @@ test('value - overwrite value method via options', function(assert) {
 
   assert.equal(validator.get('attribute'), 'foo');
   assert.equal(validator.getValue(), 'baz');
-  assert.deepEqual(validator.get('options'), {});
+  assert.notOk(validator.get('options.value'));
 });
 
 test('message - handles SafeString', function(assert) {

--- a/tests/unit/validators/base-test.js
+++ b/tests/unit/validators/base-test.js
@@ -51,22 +51,6 @@ test('buildOptions - does not overwrite options', function(assert) {
   assert.deepEqual(options.getProperties(['foo', 'bar']), { foo: 'a', bar: 'b'});
 });
 
-test('buildOptions - returned options are frozen', function(assert) {
-  assert.expect(1);
-
-  options = {
-    foo: 'a'
-  };
-
-  options = validator.buildOptions(options);
-
-  try {
-    options.set('foo', 'bar');
-  } catch (e) {
-    assert.ok(true);
-  }
-});
-
 test('createErrorMessage - message function', function(assert) {
   assert.expect(1);
 

--- a/tests/unit/validators/collection-test.js
+++ b/tests/unit/validators/collection-test.js
@@ -9,7 +9,7 @@ import {
 }
 from 'ember-qunit';
 
-var options, validator, message;
+var options, builtOptions, validator, message;
 var set = Ember.set;
 
 moduleFor('validator:collection', 'Unit | Validator | collection', {
@@ -23,19 +23,22 @@ test('buildOptions', function(assert) {
   assert.expect(2);
 
   options = true;
-  let builtOptions = validator.buildOptions(options, {});
-  assert.deepEqual(builtOptions, { collection: true });
+  builtOptions = validator.buildOptions(options, {});
+
+  assert.equal(builtOptions.get('collection'), true);
 
   options = { collection: true };
   builtOptions = validator.buildOptions(options, {});
-  assert.deepEqual(builtOptions, { collection: true });
+  assert.equal(builtOptions.get('collection'), true);
 });
 
 test('value is collection', function(assert) {
   assert.expect(1);
 
   options = { collection: true };
-  message = validator.validate(['foo', 'bar'], options);
+  builtOptions = validator.buildOptions(options);
+
+  message = validator.validate(['foo', 'bar'], builtOptions.copy());
   assert.equal(message, true);
 });
 
@@ -43,7 +46,9 @@ test('value not collection', function(assert) {
   assert.expect(1);
 
   options = { collection: true };
-  message = validator.validate('foo', options);
+  builtOptions = validator.buildOptions(options);
+
+  message = validator.validate('foo', builtOptions.copy());
   assert.equal(message, "This field must be a collection");
 });
 
@@ -51,7 +56,9 @@ test('singular - value is singular', function(assert) {
   assert.expect(1);
 
   options = { collection: false };
-  message = validator.validate('value', options);
+  builtOptions = validator.buildOptions(options);
+
+  message = validator.validate('value', builtOptions.copy());
   assert.equal(message, true);
 });
 
@@ -59,6 +66,8 @@ test('singular - value not singular', function(assert) {
   assert.expect(1);
 
   options = { collection: false };
-  message = validator.validate(['foo', 'bar'], options);
+  builtOptions = validator.buildOptions(options);
+
+  message = validator.validate(['foo', 'bar'], builtOptions.copy());
   assert.equal(message, "This field can't be a collection");
 });

--- a/tests/unit/validators/confirmation-test.js
+++ b/tests/unit/validators/confirmation-test.js
@@ -9,7 +9,7 @@ import {
 }
 from 'ember-qunit';
 
-var model, options, validator, message;
+var model, options, builtOptions, validator, message;
 var set = Ember.set;
 
 moduleFor('validator:confirmation', 'Unit | Validator | confirmation', {
@@ -23,15 +23,17 @@ test('attribute', function(assert) {
   assert.expect(2);
 
   options = { on: 'email' };
+  builtOptions = validator.buildOptions(options);
+
   model = Ember.Object.create({
     'email': 'foo@yahoo.com'
   });
 
-  message = validator.validate('bar@yahoo.com', options, model);
+  message = validator.validate('bar@yahoo.com', builtOptions.copy(), model);
   assert.equal(message, "This field doesn't match email");
 
   model.set('emailConfirmation', 'foo@yahoo.com');
 
-  message = validator.validate('foo@yahoo.com', options, model);
+  message = validator.validate('foo@yahoo.com', builtOptions.copy(), model);
   assert.equal(message, true);
 });

--- a/tests/unit/validators/date-test.js
+++ b/tests/unit/validators/date-test.js
@@ -11,7 +11,7 @@ import {
 }
 from 'ember-qunit';
 
-var options, validator, message;
+var options, builtOptions, validator, message;
 var set = Ember.set;
 const assign = Ember.assign || Ember.merge;
 
@@ -38,10 +38,12 @@ test('allow blank', function(assert) {
     before: '1/1/2015'
   };
 
-  message = validator.validate('', assign({}, options));
+  builtOptions = validator.buildOptions(options);
+
+  message = validator.validate('', builtOptions.copy());
   assert.equal(message, true);
 
-  message = validator.validate('1/1/2016', assign({}, options));
+  message = validator.validate('1/1/2016', builtOptions.copy());
   assert.equal(message, 'This field must be before Jan 1st, 2015');
 });
 
@@ -50,10 +52,12 @@ test('valid date', function(assert) {
 
   options = {};
 
-  message = validator.validate('abc', assign({}, options));
+  builtOptions = validator.buildOptions(options);
+
+  message = validator.validate('abc', builtOptions.copy());
   assert.equal(message, 'This field must be a valid date');
 
-  message = validator.validate(new Date(), assign({}, options));
+  message = validator.validate(new Date(), builtOptions.copy());
   assert.equal(message, true);
 });
 
@@ -64,10 +68,12 @@ test('valid input date format', function(assert) {
     format: 'DD/M/YYYY'
   };
 
-  message = validator.validate('27/3/15', assign({}, options));
+  builtOptions = validator.buildOptions(options);
+
+  message = validator.validate('27/3/15', builtOptions.copy());
   assert.equal(message, 'This field must be in the format of DD/M/YYYY');
 
-  message = validator.validate('27/3/2015', assign({}, options));
+  message = validator.validate('27/3/2015', builtOptions.copy());
   assert.equal(message, true);
 });
 
@@ -79,7 +85,9 @@ test('error date format', function(assert) {
     before: '1/1/2015'
   };
 
-  message = validator.validate('1/1/2016', assign({}, options));
+  builtOptions = validator.buildOptions(options);
+
+  message = validator.validate('1/1/2016', builtOptions.copy());
   assert.equal(message, 'This field must be before 1/1/2015');
 });
 
@@ -90,10 +98,12 @@ test('before', function(assert) {
     before: '1/1/2015'
   };
 
-  message = validator.validate('1/1/2016', assign({}, options));
+  builtOptions = validator.buildOptions(options);
+
+  message = validator.validate('1/1/2016', builtOptions.copy());
   assert.equal(message, 'This field must be before Jan 1st, 2015');
 
-  message = validator.validate('1/1/2014', assign({}, options));
+  message = validator.validate('1/1/2014', builtOptions.copy());
   assert.equal(message, true);
 });
 
@@ -103,10 +113,13 @@ test('before now', function(assert) {
   options = {
     before: 'now'
   };
-  message = validator.validate('1/1/3015', assign({}, options));
+
+  builtOptions = validator.buildOptions(options);
+
+  message = validator.validate('1/1/3015', builtOptions.copy());
   assert.equal(message, `This field must be before ${now}`);
 
-  message = validator.validate('1/1/2014', assign({}, options));
+  message = validator.validate('1/1/2014', builtOptions.copy());
   assert.equal(message, true);
 });
 
@@ -117,13 +130,15 @@ test('before or on', function(assert) {
     onOrBefore: '1/1/2015'
   };
 
-  message = validator.validate('1/1/2016', assign({}, options));
+  builtOptions = validator.buildOptions(options);
+
+  message = validator.validate('1/1/2016', builtOptions.copy());
   assert.equal(message, 'This field must be on or before Jan 1st, 2015');
 
-  message = validator.validate('1/1/2014', assign({}, options));
+  message = validator.validate('1/1/2014', builtOptions.copy());
   assert.equal(message, true);
 
-  message = validator.validate('1/1/2015', assign({}, options));
+  message = validator.validate('1/1/2015', builtOptions.copy());
   assert.equal(message, true);
 });
 
@@ -133,13 +148,16 @@ test('before now or on', function(assert) {
   options = {
     onOrBefore: 'now'
   };
-  message = validator.validate('1/1/3015', assign({}, options));
+
+  builtOptions = validator.buildOptions(options);
+
+  message = validator.validate('1/1/3015', builtOptions.copy());
   assert.equal(message, `This field must be on or before ${now}`);
 
-  message = validator.validate('1/1/2014', assign({}, options));
+  message = validator.validate('1/1/2014', builtOptions.copy());
   assert.equal(message, true);
 
-  message = validator.validate('now', assign({}, options));
+  message = validator.validate('now', builtOptions.copy());
   assert.equal(message, true);
 });
 
@@ -154,14 +172,18 @@ test('before or on precision', function(assert) {
   for (var i = 0; i < precisions.length; i++) {
     var precision = precisions[i];
 
-    message = validator.validate(now, { onOrBefore: dateString });
+    builtOptions = validator.buildOptions({ onOrBefore: dateString });
+
+    message = validator.validate(now, builtOptions.copy());
     assert.equal(message, true);
 
-    message = validator.validate(moment(now).add(1, precision), { onOrBefore: dateString });
+    message = validator.validate(moment(now).add(1, precision), builtOptions.copy());
     assert.equal(message, `This field must be on or before ${nowMessage}`);
 
     if ((i + 1) !== precisions.length) {
-      message = validator.validate(moment(now).add(1, precisions), { onOrBefore: dateString, precision: precisions[i + 1] });
+      builtOptions = validator.buildOptions({ onOrBefore: dateString, precision: precisions[i + 1] });
+
+      message = validator.validate(moment(now).add(1, precisions), builtOptions.copy());
       assert.equal(message, true);
     }
   }
@@ -174,10 +196,12 @@ test('after', function(assert) {
     after: '1/1/2015'
   };
 
-  message = validator.validate('1/1/2014', assign({}, options));
+  builtOptions = validator.buildOptions(options);
+
+  message = validator.validate('1/1/2014', builtOptions.copy());
   assert.equal(message, 'This field must be after Jan 1st, 2015');
 
-  message = validator.validate('1/1/2016', assign({}, options));
+  message = validator.validate('1/1/2016', builtOptions.copy());
   assert.equal(message, true);
 });
 
@@ -188,10 +212,12 @@ test('after now', function(assert) {
     after: 'now'
   };
 
-  message = validator.validate('1/1/2014', assign({}, options));
+  builtOptions = validator.buildOptions(options);
+
+  message = validator.validate('1/1/2014', builtOptions.copy());
   assert.equal(message, `This field must be after ${now}`);
 
-  message = validator.validate('1/1/3015', assign({}, options));
+  message = validator.validate('1/1/3015', builtOptions.copy());
   assert.equal(message, true);
 });
 
@@ -202,13 +228,15 @@ test('after or on', function(assert) {
     onOrAfter: '1/1/2015'
   };
 
-  message = validator.validate('1/1/2014', assign({}, options));
+  builtOptions = validator.buildOptions(options);
+
+  message = validator.validate('1/1/2014', builtOptions.copy());
   assert.equal(message, 'This field must be on or after Jan 1st, 2015');
 
-  message = validator.validate('1/1/2016', assign({}, options));
+  message = validator.validate('1/1/2016', builtOptions.copy());
   assert.equal(message, true);
 
-  message = validator.validate('1/1/2015', assign({}, options));
+  message = validator.validate('1/1/2015', builtOptions.copy());
   assert.equal(message, true);
 });
 
@@ -220,13 +248,15 @@ test('after now or on', function(assert) {
     precision: 'second'
   };
 
-  message = validator.validate('1/1/2014', assign({}, options));
+  builtOptions = validator.buildOptions(options);
+
+  message = validator.validate('1/1/2014', builtOptions.copy());
   assert.equal(message, `This field must be on or after ${now}`);
 
-  message = validator.validate('1/1/3015', assign({}, options));
+  message = validator.validate('1/1/3015', builtOptions.copy());
   assert.equal(message, true);
 
-  message = validator.validate('now', assign({}, options));
+  message = validator.validate('now', builtOptions.copy());
   assert.equal(message, true);
 });
 
@@ -241,14 +271,18 @@ test('after or on precision', function(assert) {
   for (var i = 0; i < precisions.length; i++) {
     var precision = precisions[i];
 
-    message = validator.validate(now, { onOrAfter: dateString });
+    builtOptions = validator.buildOptions({ onOrAfter: dateString });
+
+    message = validator.validate(now, builtOptions.copy());
     assert.equal(message, true);
 
-    message = validator.validate(moment(now).subtract(1, precision), { onOrAfter: dateString });
+    message = validator.validate(moment(now).subtract(1, precision), builtOptions.copy());
     assert.equal(message, `This field must be on or after ${nowMessage}`);
 
     if ((i + 1) !== precisions.length) {
-      message = validator.validate(moment(now).subtract(1, precisions), { onOrAfter: dateString, precision: precisions[i + 1] });
+      builtOptions = validator.buildOptions({ onOrAfter: dateString, precision: precisions[i + 1] });
+
+      message = validator.validate(moment(now).subtract(1, precisions), builtOptions.copy());
       assert.equal(message, true);
     }
   }

--- a/tests/unit/validators/dependent-test.js
+++ b/tests/unit/validators/dependent-test.js
@@ -14,7 +14,7 @@ const {
   run
 } = Ember;
 
-var Validator, message, model, options;
+var Validator, message, model, options, builtOptions;
 
 var Validations = buildValidations({
   firstName: validator('presence', true),
@@ -42,12 +42,14 @@ test('all empty attributes', function(assert) {
   assert.expect(5);
 
   options = defaultOptions;
+  builtOptions = Validator.buildOptions(options);
+
   model = setupObject(this, Ember.Object.extend(Validations));
 
   assert.equal(get(model, 'validations.isValid'), false);
   assert.equal(get(model, 'validations.isDirty'), false);
 
-  message = Validator.validate(undefined, options, model);
+  message = Validator.validate(undefined, builtOptions.copy(), model);
 
   assert.equal(message, "This field is invalid");
   assert.equal(get(model, 'validations.messages.length'), 2);
@@ -58,6 +60,8 @@ test('one dependent error', function(assert) {
   assert.expect(5);
 
   options = defaultOptions;
+  builtOptions = Validator.buildOptions(options);
+
   model = setupObject(this, Ember.Object.extend(Validations), {
     firstName: 'Offir'
   });
@@ -65,7 +69,7 @@ test('one dependent error', function(assert) {
   assert.equal(get(model, 'validations.isValid'), false);
   assert.equal(get(model, 'validations.isDirty'), true);
 
-  message = Validator.validate(undefined, options, model);
+  message = Validator.validate(undefined, builtOptions.copy(), model);
 
   assert.equal(message, "This field is invalid");
   assert.equal(get(model, 'validations.messages.length'), 1);
@@ -75,6 +79,7 @@ test('one dependent error', function(assert) {
 test('no dependent errors', function(assert) {
   assert.expect(5);
   options = defaultOptions;
+  builtOptions = Validator.buildOptions(options);
 
   model = setupObject(this, Ember.Object.extend(Validations), {
     firstName: 'Offir',
@@ -84,7 +89,7 @@ test('no dependent errors', function(assert) {
   assert.equal(get(model, 'validations.isValid'), true);
   assert.equal(get(model, 'validations.isDirty'), true);
 
-  message = Validator.validate(undefined, options, model);
+  message = Validator.validate(undefined, builtOptions.copy(), model);
 
   assert.equal(message, true);
   assert.equal(get(model, 'validations.messages.length'), 0);

--- a/tests/unit/validators/dependent-test.js
+++ b/tests/unit/validators/dependent-test.js
@@ -34,8 +34,14 @@ moduleFor('validator:dependent', 'Unit | Validator | dependent', {
 
 test('no options', function(assert) {
   assert.expect(1);
-  message = Validator.validate(undefined, {});
-  assert.equal(message, true);
+
+  builtOptions = Validator.buildOptions({}).copy();
+
+  try {
+    message = Validator.validate(undefined, builtOptions);
+  } catch (e) {
+    assert.ok(true);
+  }
 });
 
 test('all empty attributes', function(assert) {

--- a/tests/unit/validators/exclusion-test.js
+++ b/tests/unit/validators/exclusion-test.js
@@ -9,7 +9,7 @@ import {
 }
 from 'ember-qunit';
 
-var options, validator, message;
+var options, builtOptions, validator, message;
 var set = Ember.set;
 
 moduleFor('validator:exclusion', 'Unit | Validator | exclusion', {
@@ -22,7 +22,9 @@ moduleFor('validator:exclusion', 'Unit | Validator | exclusion', {
 test('no options', function(assert) {
   assert.expect(1);
 
-  message = validator.validate(undefined, {});
+  builtOptions = validator.buildOptions({}).copy();
+
+  message = validator.validate(undefined, builtOptions);
   assert.equal(message, true);
 });
 
@@ -33,10 +35,13 @@ test('allow blank', function(assert) {
     allowBlank: true,
     "in": ["foo", "bar", "baz"]
   };
-  message = validator.validate('', options);
+
+  builtOptions = validator.buildOptions(options);
+
+  message = validator.validate('', builtOptions.copy());
   assert.equal(message, true);
 
-  message = validator.validate('foo', options);
+  message = validator.validate('foo', builtOptions.copy());
   assert.equal(message, 'This field is reserved');
 });
 
@@ -47,17 +52,18 @@ test('not in array', function(assert) {
     "in": ["foo", "bar", "baz"]
   };
 
+  builtOptions = validator.buildOptions(options);
 
-  message = validator.validate('foo', options);
+  message = validator.validate('foo', builtOptions.copy());
   assert.equal(message, 'This field is reserved');
 
-  message = validator.validate('bar', options);
+  message = validator.validate('bar', builtOptions.copy());
   assert.equal(message, 'This field is reserved');
 
-  message = validator.validate('baz', options);
+  message = validator.validate('baz', builtOptions.copy());
   assert.equal(message, 'This field is reserved');
 
-  message = validator.validate('test', options);
+  message = validator.validate('test', builtOptions.copy());
   assert.equal(message, true);
 });
 
@@ -68,19 +74,21 @@ test('not in range', function(assert) {
     range: [1, 10]
   };
 
-  message = validator.validate(1, options);
+  builtOptions = validator.buildOptions(options);
+
+  message = validator.validate(1, builtOptions.copy());
   assert.equal(message, "This field is reserved");
 
-  message = validator.validate(5, options);
+  message = validator.validate(5, builtOptions.copy());
   assert.equal(message, "This field is reserved");
 
-  message = validator.validate(10, options);
+  message = validator.validate(10, builtOptions.copy());
   assert.equal(message, "This field is reserved");
 
-  message = validator.validate(0, options);
+  message = validator.validate(0, builtOptions.copy());
   assert.equal(message, true);
 
-  message = validator.validate(100, options);
+  message = validator.validate(100, builtOptions.copy());
   assert.equal(message, true);
 });
 
@@ -91,16 +99,18 @@ test('range type check - number', function(assert) {
     range: [1, 10]
   };
 
-  message = validator.validate(1, options);
+  builtOptions = validator.buildOptions(options);
+
+  message = validator.validate(1, builtOptions.copy());
   assert.equal(message, "This field is reserved");
 
-  message = validator.validate(5, options);
+  message = validator.validate(5, builtOptions.copy());
   assert.equal(message, "This field is reserved");
 
-  message = validator.validate('1', options);
+  message = validator.validate('1', builtOptions.copy());
   assert.equal(message, true);
 
-  message = validator.validate('5', options);
+  message = validator.validate('5', builtOptions.copy());
   assert.equal(message, true);
 });
 
@@ -111,15 +121,17 @@ test('range type check - string', function(assert) {
     range: ['a', 'z']
   };
 
-  message = validator.validate('a', options);
+  builtOptions = validator.buildOptions(options);
+
+  message = validator.validate('a', builtOptions.copy());
   assert.equal(message, "This field is reserved");
 
-  message = validator.validate('z', options);
+  message = validator.validate('z', builtOptions.copy());
   assert.equal(message, "This field is reserved");
 
-  message = validator.validate(97, options);
+  message = validator.validate(97, builtOptions.copy());
   assert.equal(message, true);
 
-  message = validator.validate('zzz', options);
+  message = validator.validate('zzz', builtOptions.copy());
   assert.equal(message, true);
 });

--- a/tests/unit/validators/exclusion-test.js
+++ b/tests/unit/validators/exclusion-test.js
@@ -23,9 +23,12 @@ test('no options', function(assert) {
   assert.expect(1);
 
   builtOptions = validator.buildOptions({}).copy();
-
-  message = validator.validate(undefined, builtOptions);
-  assert.equal(message, true);
+  
+  try {
+    message = validator.validate(undefined, builtOptions);
+  } catch (e) {
+    assert.ok(true);
+  }
 });
 
 test('allow blank', function(assert) {

--- a/tests/unit/validators/format-test.js
+++ b/tests/unit/validators/format-test.js
@@ -9,7 +9,7 @@ import {
 }
 from 'ember-qunit';
 
-var options, validator, message;
+var options, builtOptions, validator, message;
 var set = Ember.set;
 
 moduleFor('validator:format', 'Unit | Validator | format', {
@@ -23,9 +23,10 @@ test('buildOptions', function(assert) {
   assert.expect(2);
 
   options = { type: 'email' };
-  let builtOptions = validator.buildOptions(options, {});
-  assert.equal(builtOptions.type, 'email');
-  assert.ok(builtOptions.regex);
+  builtOptions = validator.buildOptions(options, {}).copy();
+  
+  assert.equal(builtOptions.get('type'), 'email');
+  assert.ok(builtOptions.get('regex'));
 });
 
 test('no options', function(assert) {
@@ -42,7 +43,7 @@ test('allow blank', function(assert) {
     allowBlank: true,
     type: 'email'
   };
-  options = validator.buildOptions(options, {});
+  options = validator.buildOptions(options, {}).copy();
 
   message = validator.validate(undefined, options);
   assert.equal(message, true);
@@ -58,7 +59,7 @@ test('email', function(assert) {
     type: 'email'
   };
 
-  options = validator.buildOptions(options, {});
+  options = validator.buildOptions(options, {}).copy();
 
   message = validator.validate('email', options);
   assert.equal(message, 'This field must be a valid email address');
@@ -77,7 +78,7 @@ test('phone', function(assert) {
     type: 'phone'
   };
 
-  options = validator.buildOptions(options, {});
+  options = validator.buildOptions(options, {}).copy();
 
   message = validator.validate('123', options);
   assert.equal(message, 'This field must be a valid phone number');
@@ -93,7 +94,7 @@ test('url', function(assert) {
     type: 'url'
   };
 
-  options = validator.buildOptions(options, {});
+  options = validator.buildOptions(options, {}).copy();
 
   message = validator.validate('yahoo', options);
   assert.equal(message, 'This field must be a valid url');
@@ -109,7 +110,7 @@ test('custom', function(assert) {
     regex: /^(?=.*\d)(?=.*[a-z])(?=.*[A-Z]).{4,8}$/
   };
 
-  options = validator.buildOptions(options, {});
+  options = validator.buildOptions(options, {}).copy();
 
   message = validator.validate('password', options);
   assert.equal(message, 'This field is invalid');

--- a/tests/unit/validators/format-test.js
+++ b/tests/unit/validators/format-test.js
@@ -24,7 +24,7 @@ test('buildOptions', function(assert) {
 
   options = { type: 'email' };
   builtOptions = validator.buildOptions(options, {}).copy();
-  
+
   assert.equal(builtOptions.get('type'), 'email');
   assert.ok(builtOptions.get('regex'));
 });
@@ -32,8 +32,13 @@ test('buildOptions', function(assert) {
 test('no options', function(assert) {
   assert.expect(1);
 
-  message = validator.validate(undefined, {});
-  assert.equal(message, true);
+  builtOptions = validator.buildOptions({}).copy();
+
+  try {
+    message = validator.validate(undefined, builtOptions);
+  } catch (e) {
+    assert.ok(true);
+  }
 });
 
 test('allow blank', function(assert) {

--- a/tests/unit/validators/inclusion-test.js
+++ b/tests/unit/validators/inclusion-test.js
@@ -22,9 +22,13 @@ moduleFor('validator:inclusion', 'Unit | Validator | inclusion', {
 test('no options', function(assert) {
   assert.expect(1);
 
-  builtOptions = validator.buildOptions({});
-  message = validator.validate(undefined, builtOptions.copy());
-  assert.equal(message, true);
+  builtOptions = validator.buildOptions({}).copy();
+
+  try {
+    message = validator.validate(undefined, builtOptions);
+  } catch (e) {
+    assert.ok(true);
+  }
 });
 
 test('allow blank', function(assert) {

--- a/tests/unit/validators/inclusion-test.js
+++ b/tests/unit/validators/inclusion-test.js
@@ -9,7 +9,7 @@ import {
 }
 from 'ember-qunit';
 
-var options, validator, message;
+var options, builtOptions, validator, message;
 var set = Ember.set;
 
 moduleFor('validator:inclusion', 'Unit | Validator | inclusion', {
@@ -22,7 +22,8 @@ moduleFor('validator:inclusion', 'Unit | Validator | inclusion', {
 test('no options', function(assert) {
   assert.expect(1);
 
-  message = validator.validate(undefined, {});
+  builtOptions = validator.buildOptions({});
+  message = validator.validate(undefined, builtOptions.copy());
   assert.equal(message, true);
 });
 
@@ -33,11 +34,12 @@ test('allow blank', function(assert) {
     allowBlank: true,
     "in": ["foo", "bar", "baz"]
   };
+  builtOptions = validator.buildOptions(options);
 
-  message = validator.validate('', options);
+  message = validator.validate('', builtOptions.copy());
   assert.equal(message, true);
 
-  message = validator.validate('test', options);
+  message = validator.validate('test', builtOptions.copy());
   assert.equal(message, 'This field is not included in the list');
 });
 
@@ -47,17 +49,18 @@ test('in array', function(assert) {
   options = {
     "in": ["foo", "bar", "baz"]
   };
+  builtOptions = validator.buildOptions(options);
 
-  message = validator.validate('test', options);
+  message = validator.validate('test', builtOptions.copy());
   assert.equal(message, 'This field is not included in the list');
 
-  message = validator.validate('foo', options);
+  message = validator.validate('foo', builtOptions.copy());
   assert.equal(message, true);
 
-  message = validator.validate('bar', options);
+  message = validator.validate('bar', builtOptions.copy());
   assert.equal(message, true);
 
-  message = validator.validate('baz', options);
+  message = validator.validate('baz', builtOptions.copy());
   assert.equal(message, true);
 });
 
@@ -67,20 +70,21 @@ test('in range', function(assert) {
   options = {
     range: [1, 10]
   };
+  builtOptions = validator.buildOptions(options);
 
-  message = validator.validate(0, options);
+  message = validator.validate(0, builtOptions.copy());
   assert.equal(message, 'This field is not included in the list');
 
-  message = validator.validate(100, options);
+  message = validator.validate(100, builtOptions.copy());
   assert.equal(message, 'This field is not included in the list');
 
-  message = validator.validate(1, options);
+  message = validator.validate(1, builtOptions.copy());
   assert.equal(message, true);
 
-  message = validator.validate(5, options);
+  message = validator.validate(5, builtOptions.copy());
   assert.equal(message, true);
 
-  message = validator.validate(10, options);
+  message = validator.validate(10, builtOptions.copy());
   assert.equal(message, true);
 });
 
@@ -90,26 +94,27 @@ test('range type check - number', function(assert) {
   options = {
     range: [1, 10]
   };
+  builtOptions = validator.buildOptions(options);
 
-  message = validator.validate('0', options);
+  message = validator.validate('0', builtOptions.copy());
   assert.equal(message, 'This field is not included in the list');
 
-  message = validator.validate(0, options);
+  message = validator.validate(0, builtOptions.copy());
   assert.equal(message, 'This field is not included in the list');
 
-  message = validator.validate('1', options);
+  message = validator.validate('1', builtOptions.copy());
   assert.equal(message, 'This field is not included in the list');
 
-  message = validator.validate('5', options);
+  message = validator.validate('5', builtOptions.copy());
   assert.equal(message, 'This field is not included in the list');
 
-  message = validator.validate(1, options);
+  message = validator.validate(1, builtOptions.copy());
   assert.equal(message, true);
 
-  message = validator.validate(5, options);
+  message = validator.validate(5, builtOptions.copy());
   assert.equal(message, true);
 
-  message = validator.validate(10, options);
+  message = validator.validate(10, builtOptions.copy());
   assert.equal(message, true);
 });
 
@@ -119,19 +124,20 @@ test('range type check - string', function(assert) {
   options = {
     range: ['a', 'z']
   };
+  builtOptions = validator.buildOptions(options);
 
-  message = validator.validate(97, options);
+  message = validator.validate(97, builtOptions.copy());
   assert.equal(message, 'This field is not included in the list');
 
-  message = validator.validate('zzz', options);
+  message = validator.validate('zzz', builtOptions.copy());
   assert.equal(message, 'This field is not included in the list');
 
-  message = validator.validate('a', options);
+  message = validator.validate('a', builtOptions.copy());
   assert.equal(message, true);
 
-  message = validator.validate('o', options);
+  message = validator.validate('o', builtOptions.copy());
   assert.equal(message, true);
 
-  message = validator.validate('z', options);
+  message = validator.validate('z', builtOptions.copy());
   assert.equal(message, true);
 });

--- a/tests/unit/validators/length-test.js
+++ b/tests/unit/validators/length-test.js
@@ -9,7 +9,7 @@ import {
 }
 from 'ember-qunit';
 
-var options, validator, message;
+var options, builtOptions, validator, message;
 var set = Ember.set;
 
 moduleFor('validator:length', 'Unit | Validator | length', {
@@ -22,7 +22,9 @@ moduleFor('validator:length', 'Unit | Validator | length', {
 test('no options', function(assert) {
   assert.expect(1);
 
-  message = validator.validate(undefined, {});
+  builtOptions = validator.buildOptions({});
+
+  message = validator.validate(undefined, builtOptions.copy());
   assert.equal(message, true);
 });
 
@@ -34,10 +36,12 @@ test('allow blank', function(assert) {
     min: 5
   };
 
-  message = validator.validate('', options);
+  builtOptions = validator.buildOptions(options);
+
+  message = validator.validate('', builtOptions.copy());
   assert.equal(message, true);
 
-  message = validator.validate('test', options);
+  message = validator.validate('test', builtOptions.copy());
   assert.equal(message, 'This field is too short (minimum is 5 characters)');
 });
 
@@ -48,12 +52,15 @@ test('allow none', function(assert) {
     // default allowNone should be true
   };
 
-  message = validator.validate(undefined, options);
+  builtOptions = validator.buildOptions(options);
+
+  message = validator.validate(undefined, builtOptions.copy());
   assert.equal(message, true);
 
   options.allowNone = false;
+  builtOptions = validator.buildOptions(options);
 
-  message = validator.validate(null, options);
+  message = validator.validate(null, builtOptions.copy());
   assert.equal(message, 'This field is invalid');
 });
 
@@ -64,10 +71,12 @@ test('is', function(assert) {
     is: 4
   };
 
-  message = validator.validate('testing', options);
+  builtOptions = validator.buildOptions(options);
+
+  message = validator.validate('testing', builtOptions.copy());
   assert.equal(message, 'This field is the wrong length (should be 4 characters)');
 
-  message = validator.validate('test', options);
+  message = validator.validate('test', builtOptions.copy());
   assert.equal(message, true);
 });
 
@@ -78,10 +87,12 @@ test('min', function(assert) {
     min: 5
   };
 
-  message = validator.validate('test', options);
+  builtOptions = validator.buildOptions(options);
+
+  message = validator.validate('test', builtOptions.copy());
   assert.equal(message, 'This field is too short (minimum is 5 characters)');
 
-  message = validator.validate('testing', options);
+  message = validator.validate('testing', builtOptions.copy());
   assert.equal(message, true);
 });
 
@@ -92,10 +103,12 @@ test('max', function(assert) {
     max: 5
   };
 
-  message = validator.validate('testing', options);
+  builtOptions = validator.buildOptions(options);
+
+  message = validator.validate('testing', builtOptions.copy());
   assert.equal(message, 'This field is too long (maximum is 5 characters)');
 
-  message = validator.validate('test', options);
+  message = validator.validate('test', builtOptions.copy());
   assert.equal(message, true);
 });
 
@@ -106,9 +119,11 @@ test('array', function(assert) {
     min: 1
   };
 
-  message = validator.validate([], options);
+  builtOptions = validator.buildOptions(options);
+
+  message = validator.validate([], builtOptions.copy());
   assert.equal(message, 'This field is too short (minimum is 1 characters)');
 
-  message = validator.validate([1], options);
+  message = validator.validate([1], builtOptions.copy());
   assert.equal(message, true);
 });

--- a/tests/unit/validators/number-test.js
+++ b/tests/unit/validators/number-test.js
@@ -9,7 +9,7 @@ import {
 }
 from 'ember-qunit';
 
-var options, validator, message;
+var options, builtOptions, validator, message;
 var set = Ember.set;
 
 moduleFor('validator:number', 'Unit | Validator | number', {
@@ -22,10 +22,12 @@ moduleFor('validator:number', 'Unit | Validator | number', {
 test('no options', function(assert) {
   assert.expect(2);
 
-  message = validator.validate(undefined, {});
+  builtOptions = validator.buildOptions({});
+
+  message = validator.validate(undefined, builtOptions.copy());
   assert.equal(message, 'This field must be a number');
 
-  message = validator.validate(22, {});
+  message = validator.validate(22, builtOptions.copy());
   assert.equal(message, true);
 });
 
@@ -35,25 +37,27 @@ test('allow string', function(assert) {
   options = {
     allowString: true
   };
+  builtOptions = validator.buildOptions(options);
 
-  message = validator.validate('22', options);
+  message = validator.validate('22', builtOptions.copy());
   assert.equal(message, true);
 
-  message = validator.validate('22.22', options);
+  message = validator.validate('22.22', builtOptions.copy());
   assert.equal(message, true);
 
-  message = validator.validate('test', options);
+  message = validator.validate('test', builtOptions.copy());
   assert.equal(message, 'This field must be a number');
 
-  message = validator.validate('', options);
+  message = validator.validate('', builtOptions.copy());
   assert.equal(message, 'This field must be a number');
 
   options.allowString = false;
+  builtOptions = validator.buildOptions(options);
 
-  message = validator.validate('22', options);
+  message = validator.validate('22', builtOptions.copy());
   assert.equal(message, 'This field must be a number');
 
-  message = validator.validate('22.22', options);
+  message = validator.validate('22.22', builtOptions.copy());
   assert.equal(message, 'This field must be a number');
 
 
@@ -65,14 +69,15 @@ test('integer', function(assert) {
   options = {
     integer: true
   };
+  builtOptions = validator.buildOptions(options);
 
-  message = validator.validate(22, options);
+  message = validator.validate(22, builtOptions.copy());
   assert.equal(message, true);
 
-  message = validator.validate(22.22, options);
+  message = validator.validate(22.22, builtOptions.copy());
   assert.equal(message, 'This field must be an integer');
 
-  message = validator.validate(-2.2, options);
+  message = validator.validate(-2.2, builtOptions.copy());
   assert.equal(message, 'This field must be an integer');
 });
 
@@ -82,11 +87,12 @@ test('is', function(assert) {
   options = {
     is: 22
   };
+  builtOptions = validator.buildOptions(options);
 
-  message = validator.validate(1, options);
+  message = validator.validate(1, builtOptions.copy());
   assert.equal(message, 'This field must be equal to 22');
 
-  message = validator.validate(22, options);
+  message = validator.validate(22, builtOptions.copy());
   assert.equal(message, true);
 });
 
@@ -96,14 +102,15 @@ test('lt', function(assert) {
   options = {
     lt: 22
   };
+  builtOptions = validator.buildOptions(options);
 
-  message = validator.validate(21, options);
+  message = validator.validate(21, builtOptions.copy());
   assert.equal(message, true);
 
-  message = validator.validate(22, options);
+  message = validator.validate(22, builtOptions.copy());
   assert.equal(message, 'This field must be less than 22');
 
-  message = validator.validate(23, options);
+  message = validator.validate(23, builtOptions.copy());
   assert.equal(message, 'This field must be less than 22');
 });
 
@@ -113,14 +120,15 @@ test('lte', function(assert) {
   options = {
     lte: 22
   };
+  builtOptions = validator.buildOptions(options);
 
-  message = validator.validate(21, options);
+  message = validator.validate(21, builtOptions.copy());
   assert.equal(message, true);
 
-  message = validator.validate(22, options);
+  message = validator.validate(22, builtOptions.copy());
   assert.equal(message, true);
 
-  message = validator.validate(23, options);
+  message = validator.validate(23, builtOptions.copy());
   assert.equal(message, 'This field must be less than or equal to 22');
 });
 
@@ -130,14 +138,15 @@ test('gt', function(assert) {
   options = {
     gt: 22
   };
+  builtOptions = validator.buildOptions(options);
 
-  message = validator.validate(21, options);
+  message = validator.validate(21, builtOptions.copy());
   assert.equal(message, 'This field must be greater than 22');
 
-  message = validator.validate(22, options);
+  message = validator.validate(22, builtOptions.copy());
   assert.equal(message, 'This field must be greater than 22');
 
-  message = validator.validate(23, options);
+  message = validator.validate(23, builtOptions.copy());
   assert.equal(message, true);
 });
 
@@ -147,14 +156,15 @@ test('gte', function(assert) {
   options = {
     gte: 22
   };
+  builtOptions = validator.buildOptions(options);
 
-  message = validator.validate(21, options);
+  message = validator.validate(21, builtOptions.copy());
   assert.equal(message, 'This field must be greater than or equal to 22');
 
-  message = validator.validate(22, options);
+  message = validator.validate(22, builtOptions.copy());
   assert.equal(message, true);
 
-  message = validator.validate(23, options);
+  message = validator.validate(23, builtOptions.copy());
   assert.equal(message, true);
 });
 
@@ -164,17 +174,18 @@ test('positive', function(assert) {
   options = {
     positive: true
   };
+  builtOptions = validator.buildOptions(options);
 
-  message = validator.validate(-1, options);
+  message = validator.validate(-1, builtOptions.copy());
   assert.equal(message, 'This field must be positive');
 
-  message = validator.validate(-144, options);
+  message = validator.validate(-144, builtOptions.copy());
   assert.equal(message, 'This field must be positive');
 
-  message = validator.validate(0, options);
+  message = validator.validate(0, builtOptions.copy());
   assert.equal(message, true);
 
-  message = validator.validate(22, options);
+  message = validator.validate(22, builtOptions.copy());
   assert.equal(message, true);
 });
 
@@ -184,17 +195,18 @@ test('odd', function(assert) {
   options = {
     odd: true
   };
+  builtOptions = validator.buildOptions(options);
 
-  message = validator.validate(22, options);
+  message = validator.validate(22, builtOptions.copy());
   assert.equal(message, 'This field must be odd');
 
-  message = validator.validate(-144, options);
+  message = validator.validate(-144, builtOptions.copy());
   assert.equal(message, 'This field must be odd');
 
-  message = validator.validate(21, options);
+  message = validator.validate(21, builtOptions.copy());
   assert.equal(message, true);
 
-  message = validator.validate(-21, options);
+  message = validator.validate(-21, builtOptions.copy());
   assert.equal(message, true);
 });
 
@@ -204,20 +216,21 @@ test('even', function(assert) {
   options = {
     even: true
   };
+  builtOptions = validator.buildOptions(options);
 
-  message = validator.validate(22, options);
+  message = validator.validate(22, builtOptions.copy());
   assert.equal(message, true);
 
-  message = validator.validate(-22, options);
+  message = validator.validate(-22, builtOptions.copy());
   assert.equal(message, true);
 
-  message = validator.validate(22.22, options);
+  message = validator.validate(22.22, builtOptions.copy());
   assert.equal(message, 'This field must be even');
 
-  message = validator.validate(21, options);
+  message = validator.validate(21, builtOptions.copy());
   assert.equal(message, 'This field must be even');
 
-  message = validator.validate(-33, options);
+  message = validator.validate(-33, builtOptions.copy());
   assert.equal(message, 'This field must be even');
 });
 
@@ -227,13 +240,14 @@ test('allowBlank', function(assert) {
   options = {
     allowBlank: true
   };
+  builtOptions = validator.buildOptions(options);
 
-  message = validator.validate(null, options);
+  message = validator.validate(null, builtOptions.copy());
   assert.equal(message, true);
 
-  message = validator.validate(undefined, options);
+  message = validator.validate(undefined, builtOptions.copy());
   assert.equal(message, true);
 
-  message = validator.validate('', options);
+  message = validator.validate('', builtOptions.copy());
   assert.equal(message, true);
 });

--- a/tests/unit/validators/presence-test.js
+++ b/tests/unit/validators/presence-test.js
@@ -9,7 +9,7 @@ import {
 }
 from 'ember-qunit';
 
-var options, validator, message;
+var options, builtOptions, validator, message;
 var set = Ember.set;
 
 moduleFor('validator:presence', 'Unit | Validator | presence', {
@@ -23,19 +23,22 @@ test('buildOptions', function(assert) {
   assert.expect(2);
 
   options = true;
-  let builtOptions = validator.buildOptions(options, {});
-  assert.deepEqual(builtOptions, { presence: true });
+  builtOptions = validator.buildOptions(options, {});
+  assert.equal(builtOptions.get('presence'), true);
 
   options = { presence: true };
   builtOptions = validator.buildOptions(options, {});
-  assert.deepEqual(builtOptions, { presence: true });
+  assert.equal(builtOptions.get('presence'), true);
 });
 
 test('presence - value present', function(assert) {
   assert.expect(1);
 
   options = { presence: true };
-  message = validator.validate('value', options);
+
+  builtOptions = validator.buildOptions(options);
+
+  message = validator.validate('value', builtOptions.copy());
   assert.equal(message, true);
 });
 
@@ -43,7 +46,10 @@ test('presence - value blank', function(assert) {
   assert.expect(1);
 
   options = { presence: true };
-  message = validator.validate(' ', options);
+
+  builtOptions = validator.buildOptions(options);
+
+  message = validator.validate(' ', builtOptions.copy());
   assert.equal(message, true);
 });
 
@@ -51,7 +57,10 @@ test('presence with ignoreBlank - value blank', function(assert) {
   assert.expect(1);
 
   options = { presence: true, ignoreBlank: true };
-  message = validator.validate(' ', options);
+
+  builtOptions = validator.buildOptions(options);
+
+  message = validator.validate(' ', builtOptions.copy());
   assert.equal(message, "This field can't be blank");
 });
 
@@ -59,7 +68,9 @@ test('presence - value not present', function(assert) {
   assert.expect(1);
 
   options = { presence: true };
-  message = validator.validate(undefined, options);
+  builtOptions = validator.buildOptions(options);
+
+  message = validator.validate(undefined, builtOptions.copy());
   assert.equal(message, "This field can't be blank");
 });
 
@@ -67,7 +78,9 @@ test('absence - value present', function(assert) {
   assert.expect(1);
 
   options = { presence: false };
-  message = validator.validate('value', options);
+  builtOptions = validator.buildOptions(options);
+
+  message = validator.validate('value', builtOptions.copy());
   assert.equal(message, "This field must be blank");
 });
 
@@ -75,7 +88,8 @@ test('absence - value not present', function(assert) {
   assert.expect(1);
 
   options = { presence: false };
+  builtOptions = validator.buildOptions(options);
 
-  message = validator.validate(undefined, options);
+  message = validator.validate(undefined, builtOptions.copy());
   assert.equal(message, true);
 });


### PR DESCRIPTION
Replace `Options as Functions` with CPs

```js
username: {
    dependentKeys: ['model.foo'],
    description: computed.alias('model.usernameDesc'),
    validators: [
      validator('presence', true),
      validator('length', {
        min: computed.alias('model.minLength')
      })
    ]
  }
```

Features:

1. Any property can now be a CP with access to the `model` and `attribute`
2. Dependent keys are __extracted__ from the CPs and added to the top level CP (`validations.attrs.username`)
3. Options that must be constantly recomputed, you can just use `volatile` 
4. `dependentKeys: ['foo']` --> `dependentKeys: ['model.foo']` to match CP dependentKey declaration

Special thanks to @xcambar for first introducing this idea to me. 

Open for review: @stefanpenner @rwjblue @blimmer 