### PR TITLE
Check for null in extractOptionsDependentKeys

### DIFF
--- a/addon/validations/factory.js
+++ b/addon/validations/factory.js
@@ -503,7 +503,7 @@ function extractOptionsDependentKeys(options) {
     return Object.keys(options).reduce((arr, key) => {
       let option = options[key];
 
-      if(typeof option === 'object' && option.isDescriptor) {
+      if(option && typeof option === 'object' && option.isDescriptor) {
         return arr.concat(option._dependentKeys || []);
       }
 


### PR DESCRIPTION
Changes proposed:

 - Adds a check for null in `extractOptionsDependentKeys` (because `typeof null === "object"`)

