### PR TITLE
Fix null value for the message

### DIFF
--- a/tests/integration/validations/factory-general-test.js
+++ b/tests/integration/validations/factory-general-test.js
@@ -292,6 +292,20 @@ test("custom messages object", function(assert) {
   assert.equal(object.get('validations.attrs.firstName.message'), 'Test error message');
 });
 
+test("null message object", function(assert) {
+  this.register('validator:messages', DefaultMessages);
+  var Validations = buildValidations({
+    firstName: validator('presence', {
+      presence: true,
+      message: null
+    })
+  });
+
+  var object = setupObject(this, Ember.Object.extend(Validations));
+
+  assert.equal(object.get('validations.attrs.firstName.message'), 'This field can\'t be blank');
+});
+
 test("debounced validations", function(assert) {
   var done = assert.async();
   var initSetup = true;


### PR DESCRIPTION
Changes proposed:

 - on `extractOptionsDependentKeys`: `typeof null === "object"`

Tasks:

- [x] Added test case(s): The default message is available!
