### PR TITLE
[BUGFIX] Validate promise resolves even when validations are still validating

### DIFF
--- a/addon/validations/factory.js
+++ b/addon/validations/factory.js
@@ -447,7 +447,8 @@ function createTopLevelPropsMixin(validatableAttrs) {
           promises.push(get(validation, '_promise'));
         }
       });
-      return RSVP.Promise.all(flatten(promises));
+      
+      return RSVP.allSettled(flatten(promises));
     }).readOnly()
   });
 }
@@ -724,9 +725,9 @@ function validate(options = {}, async = true) {
 
   if (async) {
     if (get(validationResultsCollection, 'isAsync')) {
-      resultObject.promise = get(validationResultsCollection, 'value');
+      return get(validationResultsCollection, '_promise').then(() => resultObject);
     }
-    return RSVP.hash(resultObject);
+    return Promise.resolve(resultObject);
   }
 
   return resultObject;

--- a/addon/validations/factory.js
+++ b/addon/validations/factory.js
@@ -447,7 +447,7 @@ function createTopLevelPropsMixin(validatableAttrs) {
           promises.push(get(validation, '_promise'));
         }
       });
-      
+
       return RSVP.allSettled(flatten(promises));
     }).readOnly()
   });
@@ -714,18 +714,18 @@ function validate(options = {}, async = true) {
     return v;
   }, []);
 
-  const validationResultsCollection = ValidationResultCollection.create({
+  const resultCollection = ValidationResultCollection.create({
     content: validationResults
   });
 
   const resultObject = {
     model,
-    validations: validationResultsCollection
+    validations: resultCollection
   };
 
   if (async) {
-    if (get(validationResultsCollection, 'isAsync')) {
-      return get(validationResultsCollection, '_promise').then(() => resultObject);
+    if (get(resultCollection, 'isAsync')) {
+      return RSVP.allSettled(makeArray(get(resultCollection, '_promise'))).then(() => resultObject);
     }
     return Promise.resolve(resultObject);
   }

--- a/addon/validations/result-collection.js
+++ b/addon/validations/result-collection.js
@@ -367,10 +367,11 @@ export default Ember.Object.extend({
    * @type {Promise}
    */
   _promise: computed('content.@each._promise', cycleBreaker(function () {
-    const promises = get(this, 'content').getEach('_promise');
+    let promises = get(this, 'content').getEach('_promise');
+    promises = compact(flatten(promises));
 
     if (!isEmpty(promises)) {
-      return RSVP.all(compact(flatten(promises)));
+      return RSVP.allSettled(promises);
     }
   })).readOnly(),
 

--- a/addon/validations/result.js
+++ b/addon/validations/result.js
@@ -180,6 +180,7 @@ const Result = Ember.Object.extend({
       set(this, '_validations', result);
     } else if (isArray(result)) {
       const validationResultsCollection = ValidationResultCollection.create({
+        isValidations: true,
         attribute,
         content: result.map(r => Result.create({
           attribute,
@@ -201,6 +202,14 @@ const Result = Ember.Object.extend({
     }
   },
 
+  _setIsValidating(value) {
+    const validations = get(this, '_validations');
+
+    if(!get(validations, 'isValidations')) {
+      set(validations, 'isValidating', value);
+    }
+  },
+
   /**
    * Promise handler
    * @method  _handlePromise
@@ -209,21 +218,22 @@ const Result = Ember.Object.extend({
   _handlePromise() {
     const validations = get(this, '_validations');
 
-    set(validations, 'isValidating', true);
-    get(this, '_promise').then(
+    this._setIsValidating(true);
+
+    get(validations, '_promise').then(
       result => {
-        set(validations, 'isValidating', false);
+        this._setIsValidating(false);
         return this.update(result);
       },
       result => {
-        set(validations, 'isValidating', false);
+        this._setIsValidating(false);
         return this.update(result);
       }
     ).catch(reason => {
       // TODO: send into error state
       throw reason;
     }).finally(() => {
-      set(validations, 'isValidating', false);
+      this._setIsValidating(false);
     });
   }
 });

--- a/addon/validators/belongs-to.js
+++ b/addon/validators/belongs-to.js
@@ -79,7 +79,7 @@ const {
  *  @module Validators
  *  @extends Base
  */
-const BelongsTo = Base.extend({
+export default Base.extend({
   validate(value) {
     if (value) {
       if (canInvoke(value, 'then')) {
@@ -91,11 +91,3 @@ const BelongsTo = Base.extend({
     return true;
   }
 });
-
-BelongsTo.reopenClass({
-  getDependentsFor(attribute) {
-    return [ `${attribute}.isTruelyValid` ];
-  }
-});
-
-export default BelongsTo;

--- a/addon/validators/has-many.js
+++ b/addon/validators/has-many.js
@@ -70,7 +70,7 @@ const HasMany = Base.extend({
 
 HasMany.reopenClass({
   getDependentsFor(attribute) {
-    return [ `model.${attribute}.[]`, `${attribute}.@each.isTruelyValid` ];
+    return [ `model.${attribute}.[]` ];
   }
 });
 

--- a/tests/unit/validations/nested-model-relationship-test.js
+++ b/tests/unit/validations/nested-model-relationship-test.js
@@ -16,7 +16,7 @@ moduleForModel('order', 'Unit | Validations | Nested Model Relationships', {
 });
 
 test("order with invalid question shows invalid", function(assert) {
-  assert.expect(7);
+  assert.expect(11);
   var order = this.subject({source: 'external'});
 
   var orderLine, orderSelection, orderSelectionQuestion;
@@ -26,31 +26,36 @@ test("order with invalid question shows invalid", function(assert) {
     orderLine = store.createRecord('order-line', { order: order, type: "item" });
     orderSelection = store.createRecord('order-selection', { order: order, line: orderLine, quantity: 1 });
     orderSelectionQuestion = store.createRecord('order-selection-question', { order: order, selection: orderSelection });
+    store.createRecord('order-selection-question', { order: order, selection: orderSelection, text: 'foo' });
   });
 
   assert.equal(order.get('lines.length'), 1, 'Order has 1 Order Line');
   assert.equal(orderLine.get('selections.length'), 1, 'Order Line has 1 Order Selection');
-  assert.equal(orderSelection.get('questions.length'), 1, 'Order Selection has 1 Order Selection Question');
+  assert.equal(orderSelection.get('questions.length'), 2, 'Order Selection has 2 Order Selection Questions');
 
   let done = assert.async();
 
   order.validate().then(({ validations }) => {
+    assert.equal(validations.get('isValidating'), false, 'All promises should be resolved');
     assert.equal(validations.get('isValid'), false, 'Order should not be valid because of Order Selection Question');
     return orderLine.validate();
   }).then(({ validations }) => {
+    assert.equal(validations.get('isValidating'), false, 'All promises should be resolved');
     assert.equal(validations.get('isValid'), false, 'Order Line should not be valid because of Order Selection Question');
     return orderSelection.validate();
   }).then(({ validations}) => {
+    assert.equal(validations.get('isValidating'), false, 'All promises should be resolved');
     assert.equal(validations.get('isValid'), false, 'Order Selection should not be valid because of Order Selection Question');
     return orderSelectionQuestion.validate();
   }).then(({ validations}) => {
+    assert.equal(validations.get('isValidating'), false, 'All promises should be resolved');
     assert.equal(validations.get('isValid'), false, 'Order Selection Question should not be valid');
     done();
   });
 });
 
 test("order with valid question shows valid", function(assert) {
-  assert.expect(7);
+  assert.expect(11);
   var order = this.subject({source: 'external'});
 
   var orderLine, orderSelection, orderSelectionQuestion;
@@ -69,22 +74,26 @@ test("order with valid question shows valid", function(assert) {
   let done = assert.async();
 
   order.validate().then(({ validations }) => {
+    assert.equal(validations.get('isValidating'), false, 'All promises should be resolved');
     assert.equal(validations.get('isValid'), true, 'Order should be valid because of Order Selection Question');
     return orderLine.validate();
   }).then(({ validations }) => {
+    assert.equal(validations.get('isValidating'), false, 'All promises should be resolved');
     assert.equal(validations.get('isValid'), true, 'Order Line should be valid because of Order Selection Question');
     return orderSelection.validate();
   }).then(({ validations}) => {
+    assert.equal(validations.get('isValidating'), false, 'All promises should be resolved');
     assert.equal(validations.get('isValid'), true, 'Order Selection should be valid because of Order Selection Question');
     return orderSelectionQuestion.validate();
   }).then(({ validations}) => {
+    assert.equal(validations.get('isValidating'), false, 'All promises should be resolved');
     assert.equal(validations.get('isValid'), true, 'Order Selection Question should be valid');
     done();
   });
 });
 
 test("order with invalid question shows invalid if validated in reverse order", function(assert) {
-  assert.expect(7);
+  assert.expect(11);
   var order = this.subject({source: 'external'});
 
   var orderLine, orderSelection, orderSelectionQuestion;
@@ -103,22 +112,26 @@ test("order with invalid question shows invalid if validated in reverse order", 
   let done = assert.async();
 
   orderSelectionQuestion.validate().then(({ validations }) => {
+    assert.equal(validations.get('isValidating'), false, 'All promises should be resolved');
     assert.equal(validations.get('isValid'), false, 'Order Selection Question should not be valid');
     return orderSelection.validate();
   }).then(({ validations }) => {
+    assert.equal(validations.get('isValidating'), false, 'All promises should be resolved');
     assert.equal(validations.get('isValid'), false, 'Order Selection should not be valid because of Order Selection Question');
     return orderLine.validate();
   }).then(({ validations}) => {
+    assert.equal(validations.get('isValidating'), false, 'All promises should be resolved');
     assert.equal(validations.get('isValid'), false, 'Order Line should not be valid because of Order Selection Question');
     return order.validate();
   }).then(({ validations}) => {
+    assert.equal(validations.get('isValidating'), false, 'All promises should be resolved');
     assert.equal(validations.get('isValid'), false, 'Order should not be valid because of Order Selection Question');
     done();
   });
 });
 
 test("order with valid question shows valid if validated in reverse order", function(assert) {
-  assert.expect(7);
+  assert.expect(11);
   var order = this.subject({source: 'external'});
 
   var orderLine, orderSelection, orderSelectionQuestion;
@@ -137,15 +150,19 @@ test("order with valid question shows valid if validated in reverse order", func
   let done = assert.async();
 
   orderSelectionQuestion.validate().then(({ validations }) => {
+    assert.equal(validations.get('isValidating'), false, 'All promises should be resolved');
     assert.equal(validations.get('isValid'), true, 'Order Selection Question should be valid');
     return orderSelection.validate();
   }).then(({ validations }) => {
+    assert.equal(validations.get('isValidating'), false, 'All promises should be resolved');
     assert.equal(validations.get('isValid'), true, 'Order Selection should be valid because of Order Selection Question');
     return orderLine.validate();
   }).then(({ validations}) => {
+    assert.equal(validations.get('isValidating'), false, 'All promises should be resolved');
     assert.equal(validations.get('isValid'), true, 'Order Line should be valid because of Order Selection Question');
     return order.validate();
   }).then(({ validations}) => {
+    assert.equal(validations.get('isValidating'), false, 'All promises should be resolved');
     assert.equal(validations.get('isValid'), true, 'Order should be valid because of Order Selection Question');
     done();
   });


### PR DESCRIPTION
Resolves #283.

Changes proposed:

 - Use RSVP.allSettled to make sure all promises will be resolved
 - Implement readOnly property for Result class to determine if the InternalResultObject can be modified

Tasks:

- [x] Added test case(s)
- [x] Updated documentation
