### PR TITLE
[FEATURE] Lazily run validations

### DIFF
--- a/addon/utils/utils.js
+++ b/addon/utils/utils.js
@@ -5,6 +5,10 @@
 
 import Ember from 'ember';
 
+const {
+  canInvoke
+} = Ember;
+
 export function requireModule(module) {
   return self.requirejs.has(module) ? self.require(module).default : undefined;
 }
@@ -15,4 +19,8 @@ export function unwrapString(input) {
   }
 
   return input;
+}
+
+export function isPromise(p) {
+  return !!(p && canInvoke(p, 'then'));
 }

--- a/addon/validations/factory.js
+++ b/addon/validations/factory.js
@@ -355,20 +355,15 @@ function createCPValidationFor(attribute, validations, owner) {
   return computed(...dependentKeys, cycleBreaker(function () {
     const model = get(this, '_model');
     const validators = !isNone(model) ? getValidatorsFor(attribute, model) : [];
-    const resultCollectionContent = [];
-    let value, validationResult, resultCollection;
+    const resultCollection = ValidationResultCollection.create({ attribute, content: [] });
+    let value, validationResult;
+    let collectionContent = [];
 
     validators.forEach(validator => {
       const options = get(validator, 'options').copy();
       const debounce = getWithDefault(options, 'debounce', 0);
       const disabled = getWithDefault(options, 'disabled', false);
       const lazy = getWithDefault(options, 'lazy', true);
-
-      /*
-        Create a temporary ResultCollection to be able to check the current validation state
-        of the attribute
-       */
-      resultCollection = ValidationResultCollection.create({ content: resultCollectionContent });
 
       if(disabled) {
         value = true;
@@ -394,10 +389,14 @@ function createCPValidationFor(attribute, validations, owner) {
       }
 
       validationResult = validationReturnValueHandler(attribute, value, model, validator);
-      resultCollectionContent.push(validationResult);
+      resultCollection.pushObject(validationResult);
+      console.log(attribute, 'result pushed');
     });
 
-    return ValidationResultCollection.create({ attribute, content: resultCollectionContent });
+    console.log('content: ', resultCollection.get('content'));
+    console.log('errorContent: ', resultCollection.get('_errorContent'));
+
+    return resultCollection;
   })).readOnly();
 }
 

--- a/addon/validations/factory.js
+++ b/addon/validations/factory.js
@@ -395,23 +395,6 @@ function createCPValidationFor(attribute, validations, owner) {
   })).readOnly();
 }
 
-
-/**
- * Returns a filtered set of validators that should be validated against
- *
- * @method filterValidatableValidators
- * @param  {Array}  validators
- * @return {Array}
- */
-function filterValidatableValidators(validators = []) {
-  return validators.filter(validator => {
-    const options = get(validator, 'options').copy();
-    const disabled = getWithDefault(options, 'disabled', false);
-
-    return !disabled;
-  });
-}
-
 /**
  * Create a mixin that will have all the top level CPs under the validations object.
  * These are computed collections on different properties of each attribute validations CP
@@ -761,9 +744,10 @@ function validateAttribute(attribute, value) {
   const model = get(this, 'model');
   const validators = !isNone(model) ? getValidatorsFor(attribute, model) : [];
 
-  const validationResults = filterValidatableValidators(validators).map(validator => {
+  const validationResults = validators.map(validator => {
     const options = get(validator, 'options').copy();
-    let result = validator.validate(value, options, model, attribute);
+    const disabled = getWithDefault(options, 'disabled', false);
+    let result = disabled ? true : validator.validate(value, options, model, attribute);
 
     return validationReturnValueHandler(attribute, result, model, validator);
   });

--- a/addon/validations/factory.js
+++ b/addon/validations/factory.js
@@ -35,12 +35,6 @@ const {
   Promise
 } = RSVP;
 
-const {
-  and,
-  or,
-  not
-} = computed;
-
 /**
  * ## Running Manual Validations
  *
@@ -400,60 +394,40 @@ function createCPValidationFor(attribute, validations, owner) {
  * @param  {Object} validations
  */
 function createTopLevelPropsMixin(validatableAttrs) {
-  return Ember.Mixin.create({
-    isWarning: and(...validatableAttrs.map(attr => `attrs.${attr}.isWarning`)).readOnly(),
-    isValid: and(...validatableAttrs.map(attr => `attrs.${attr}.isValid`)).readOnly(),
-    isValidating: or(...validatableAttrs.map(attr => `attrs.${attr}.isValidating`)).readOnly(),
-    isDirty: or(...validatableAttrs.map(attr => `attrs.${attr}.isDirty`)).readOnly(),
-    isAsync: or(...validatableAttrs.map(attr => `attrs.${attr}.isAsync`)).readOnly(),
-    isNotValidating: not('isValidating').readOnly(),
-    isInvalid: not('isValid').readOnly(),
-    isTruelyValid: and('isValid', 'isNotValidating').readOnly(),
+  // Expose the following properties as public APIs via readOnly aliases
+  const aliases = [
+    'isWarning',
+    'isValid',
+    'isValidating',
+    'isDirty',
+    'isAsync',
+    'isNotValidating',
+    'isInvalid',
+    'isTruelyValid',
+    'messages',
+    'message',
+    'warningMessages',
+    'warningMessage',
+    'warnings',
+    'warning',
+    'errors',
+    'error',
+    '_promise'
+  ];
 
-    messages: computed(...validatableAttrs.map(attr => `attrs.${attr}.messages`), function () {
-      return emberArray(flatten(validatableAttrs.map(attr => get(this, `attrs.${attr}.messages`)))).compact();
-    }).readOnly(),
+  const topLevelProps = aliases.reduce((props, alias) => {
+    props[alias] = computed.readOnly(`__attrsResultCollection__.${alias}`);
+    return props;
+  }, {});
 
-    message: computed('messages.[]', cycleBreaker(function () {
-      return get(this, 'messages.firstObject');
-    })).readOnly(),
-
-    warningMessages: computed(...validatableAttrs.map(attr => `attrs.${attr}.warningMessages`), function () {
-      return emberArray(flatten(validatableAttrs.map(attr => get(this, `attrs.${attr}.warningMessages`)))).compact();
-    }).readOnly(),
-
-    warningMessage: computed('warningMessages.[]', cycleBreaker(function () {
-      return get(this, 'warningMessages.firstObject');
-    })).readOnly(),
-
-    warnings: computed(...validatableAttrs.map(attr => `attrs.${attr}.@each.warnings`), function () {
-      return emberArray(flatten(validatableAttrs.map(attr => get(this, `attrs.${attr}.warnings`)))).compact();
-    }).readOnly(),
-
-    warning: computed('warning.[]', cycleBreaker(function () {
-      return get(this, 'warning.firstObject');
-    })).readOnly(),
-
-    errors: computed(...validatableAttrs.map(attr => `attrs.${attr}.@each.errors`), function () {
-      return emberArray(flatten(validatableAttrs.map(attr => get(this, `attrs.${attr}.errors`)))).compact();
-    }).readOnly(),
-
-    error: computed('errors.[]', cycleBreaker(function () {
-      return get(this, 'errors.firstObject');
-    })).readOnly(),
-
-    _promise: computed(...validatableAttrs.map(attr => `attrs.${attr}._promise`), function () {
-      const promises = [];
-
-      validatableAttrs.forEach(attr => {
-        const validation = get(this, `attrs.${attr}`);
-
-        if (get(validation, 'isAsync')) {
-          promises.push(get(validation, '_promise'));
-        }
+  return Ember.Mixin.create(topLevelProps, {
+    /*
+      Dedupe logic by creating a top level ResultCollection for all attr's ResultCollections
+     */
+    __attrsResultCollection__: computed(...validatableAttrs.map(attr => `attrs.${attr}`), function () {
+      return ValidationResultCollection.create({
+        content: validatableAttrs.map(attr => get(this, `attrs.${attr}`))
       });
-
-      return RSVP.allSettled(flatten(promises));
     }).readOnly()
   });
 }

--- a/addon/validations/internal-result-object.js
+++ b/addon/validations/internal-result-object.js
@@ -20,8 +20,7 @@ const {
 
 const {
   and,
-  not,
-  readOnly
+  not
 } = computed;
 
 export default Ember.Object.extend({

--- a/addon/validations/internal-result-object.js
+++ b/addon/validations/internal-result-object.js
@@ -20,7 +20,8 @@ const {
 
 const {
   and,
-  not
+  not,
+  readOnly
 } = computed;
 
 export default Ember.Object.extend({
@@ -33,19 +34,21 @@ export default Ember.Object.extend({
   attrValue: null,
   _promise: null,
   _validator: null,
-  _promiseResolved: false,
 
   init() {
     this._super(...arguments);
-    this._handlePromise();
+
+    if(this.get('isAsync')) {
+      this._handlePromise();
+    }
   },
 
-  isNotValidating: not('isValidating'),
   isInvalid: not('isValid'),
+  isNotValidating: not('isValidating'),
   isTruelyValid: and('isNotValidating', 'isValid'),
 
-  isAsync: computed('_promise', '_promiseResolved', function () {
-    return isPromise(get(this, '_promise')) && !get(this, '_promiseResolved');
+  isAsync: computed('_promise', function () {
+    return isPromise(get(this, '_promise'));
   }),
 
   isDirty: computed('attrValue', function () {
@@ -87,11 +90,16 @@ export default Ember.Object.extend({
     return makeArray(get(this, 'error'));
   }),
 
+  /**
+   * Promise handler
+   * @method  _handlePromise
+   * @private
+   */
   _handlePromise() {
-    const promise = get(this, '_promise');
+    set(this, 'isValidating', true);
 
-    if(isPromise(promise)) {
-      promise.finally(() => set(this, '_promiseResolved', true));
-    }
+    get(this, '_promise').finally(() => {
+      set(this, 'isValidating', false);
+    });
   }
 });

--- a/addon/validations/result-collection.js
+++ b/addon/validations/result-collection.js
@@ -37,7 +37,6 @@ function each(collection, key, fn) {
 
 function isAny(collection, key, value, defaultValue) {
   return each(collection, key, cycleBreaker(function () {
-    console.log(`inside ${key}`, get(this, collection));
     return get(this, collection).isAny(key, value);
   }, defaultValue));
 }
@@ -61,6 +60,7 @@ export default Ember.ArrayProxy.extend({
 
   /**
    * The attribute that this collection belongs to
+   *
    * @property attribute
    * @type {String}
    */
@@ -88,6 +88,7 @@ export default Ember.ArrayProxy.extend({
    * ```
    *
    * @property isInvalid
+   * @default false
    * @readOnly
    * @type {Boolean}
    */
@@ -356,9 +357,7 @@ export default Ember.ArrayProxy.extend({
    * @type {Array}
    * @private
    */
-  _contentValidators: each('_errorContent', '_validator', function() {
-    return get(this, '_errorContent').mapBy('_validator');
-  }).readOnly(),
+  _contentValidators: computed.mapBy('_errorContent', '_validator').readOnly(),
 
   /**
    * @property _errorContent

--- a/addon/validations/result-collection.js
+++ b/addon/validations/result-collection.js
@@ -31,18 +31,14 @@ const compact = callable('compact');
 /*
   CP Macros
  */
-function each(collection, key, fn) {
-  return computed(`${collection}.[]`, `${collection}.@each.${key}`, fn);
-}
-
 function isAny(collection, key, value, defaultValue) {
-  return each(collection, key, cycleBreaker(function () {
+  return computed(`${collection}.@each.${key}`, cycleBreaker(function () {
     return get(this, collection).isAny(key, value);
   }, defaultValue));
 }
 
 function isEvery(collection, key, value, defaultValue) {
-  return each(collection, key, cycleBreaker(function () {
+  return computed(`${collection}.@each.${key}`, cycleBreaker(function () {
     return get(this, collection).isEvery(key, value);
   }, defaultValue));
 }
@@ -92,7 +88,7 @@ export default Ember.ArrayProxy.extend({
    * @readOnly
    * @type {Boolean}
    */
-  isInvalid: isAny('_errorContent', 'isInvalid', true, false).readOnly(),
+  isInvalid: computed.not('isValid').readOnly(),
 
   /**
    * ```javascript
@@ -187,7 +183,7 @@ export default Ember.ArrayProxy.extend({
    * @readOnly
    * @type {Array}
    */
-  messages: each('_errorContent', 'messages', cycleBreaker(function () {
+  messages: computed('_errorContent.@each.messages', cycleBreaker(function () {
     const messages = flatten(get(this, '_errorContent').getEach('messages'));
     return uniq(compact(messages));
   })).readOnly(),
@@ -220,7 +216,7 @@ export default Ember.ArrayProxy.extend({
    * @readOnly
    * @type {Array}
    */
-  warningMessages: each('_warningContent', 'messages', cycleBreaker(function () {
+  warningMessages: computed('_warningContent.@each.messages', cycleBreaker(function () {
     const messages = flatten(get(this, '_warningContent').getEach('messages'));
     return uniq(compact(messages));
   })).readOnly(),
@@ -254,7 +250,7 @@ export default Ember.ArrayProxy.extend({
    * @readOnly
    * @type {Array}
    */
-  warnings: each('_warningContent', 'errors', cycleBreaker(function () {
+  warnings: computed('attribute', '_warningContent.@each.errors', cycleBreaker(function () {
     return computeErrorCollection(get(this, 'attribute'), get(this, '_warningContent'));
   })).readOnly(),
 
@@ -287,7 +283,7 @@ export default Ember.ArrayProxy.extend({
    * @readOnly
    * @type {Array}
    */
-  errors: each('_errorContent', 'errors', cycleBreaker(function () {
+  errors: computed('attribute', '_errorContent.@each.errors', cycleBreaker(function () {
     return computeErrorCollection(get(this, 'attribute'), get(this, '_errorContent'));
   })).readOnly(),
 
@@ -338,7 +334,7 @@ export default Ember.ArrayProxy.extend({
    * @readOnly
    * @type {Object}
    */
-  options: each('_contentValidators', 'options', function () {
+  options: computed('_contentValidators.@each.options', function () {
     return groupValidatorOptions(get(this, '_contentValidators'));
   }).readOnly(),
 
@@ -348,7 +344,7 @@ export default Ember.ArrayProxy.extend({
    * @private
    * @type {Promise}
    */
-  _promise: each('content', '_promise', cycleBreaker(function () {
+  _promise: computed('content.@each._promise', cycleBreaker(function () {
     return RSVP.allSettled(compact(flatten(this.getEach('_promise'))));
   })).readOnly(),
 

--- a/addon/validations/result-collection.js
+++ b/addon/validations/result-collection.js
@@ -12,7 +12,6 @@ const {
   set,
   RSVP,
   computed,
-  isEmpty,
   isArray,
   isNone,
   A: emberArray
@@ -47,11 +46,11 @@ export default Ember.Object.extend({
    * @property attribute
    * @type {String}
    */
-  attribute: '',
+  attribute: null,
 
   init() {
     this._super(...arguments);
-    set(this, 'content', emberArray(get(this, 'content')));
+    set(this, 'content', emberArray(compact(get(this, 'content'))));
   },
 
   /**
@@ -188,7 +187,6 @@ export default Ember.Object.extend({
    */
   messages: computed('_errorContent.@each.messages', cycleBreaker(function () {
     const messages = flatten(get(this, '_errorContent').getEach('messages'));
-
     return uniq(compact(messages));
   })).readOnly(),
 
@@ -224,7 +222,6 @@ export default Ember.Object.extend({
    */
   warningMessages: computed('_warningContent.@each.messages', cycleBreaker(function () {
     const messages = flatten(get(this, '_warningContent').getEach('messages'));
-
     return uniq(compact(messages));
   })).readOnly(),
 
@@ -368,11 +365,7 @@ export default Ember.Object.extend({
    */
   _promise: computed('content.@each._promise', cycleBreaker(function () {
     let promises = get(this, 'content').getEach('_promise');
-    promises = compact(flatten(promises));
-
-    if (!isEmpty(promises)) {
-      return RSVP.allSettled(promises);
-    }
+    return RSVP.allSettled(compact(flatten(promises)));
   })).readOnly(),
 
   /**
@@ -407,7 +400,7 @@ export default Ember.Object.extend({
 
     errors = uniq(compact(errors));
     errors.forEach(e => {
-      if(e.get('attribute') !== attribute) {
+      if(attribute && e.get('attribute') !== attribute) {
         e.set('parentAttribute', attribute);
       }
     });

--- a/addon/validations/result.js
+++ b/addon/validations/result.js
@@ -71,7 +71,6 @@ const Result = Ember.Object.extend({
    */
   _isReadOnly: computed('_validations', function() {
     const validations = get(this, '_validations');
-
     return (validations instanceof ValidationResultCollection) || get(validations, 'isValidations');
   }).readOnly(),
 
@@ -228,24 +227,12 @@ const Result = Ember.Object.extend({
    * @private
    */
   _handlePromise() {
-    const validations = get(this, '_validations');
-
-    set(validations, 'isValidating', true);
-
     get(this, '_promise').then(
-      result => {
-        set(validations, 'isValidating', false);
-        return this.update(result);
-      },
-      result => {
-        set(validations, 'isValidating', false);
-        return this.update(result);
-      }
+      result => this.update(result),
+      result => this.update(result)
     ).catch(reason => {
       // TODO: send into error state
       throw reason;
-    }).finally(() => {
-      set(validations, 'isValidating', false);
     });
   }
 });

--- a/addon/validations/result.js
+++ b/addon/validations/result.js
@@ -159,7 +159,9 @@ const Result = Ember.Object.extend({
    * @type {Result}
    */
   _validations: computed('model', 'attribute', '_promise', '_validator', function () {
-    return InternalResultObject.create(getProperties(this, ['model', 'attribute', '_promise', '_validator']));
+    return InternalResultObject.extend({
+      attrValue: computed.readOnly(`model.${get(this, 'attribute')}`)
+    }).create(getProperties(this, ['model', 'attribute', '_promise', '_validator']));
   }),
 
   init() {

--- a/addon/validations/validator.js
+++ b/addon/validations/validator.js
@@ -16,7 +16,9 @@ const {
 /**
  * ### description
  *
- * A descriptor for your attribute used in the error message strings. Defaults to `This field'`.
+ * Default: __'This field'__
+ *
+ * A descriptor for your attribute used in the error message strings.
  * You can overwrite this value in your `validators/messages.js` file by changing the `defaultDescription` property.
  *
  * ```javascript
@@ -26,6 +28,30 @@ const {
  * })
  * // If validation is run and the attribute is empty, the error returned will be:
  * // 'Date of birth can't be blank'
+ * ```
+ *
+ * ### lazy
+ *
+ * Default: __true__
+ *
+ * Only validate the given validator if the attribute is not already in an invalid
+ * state. When you have multiple validators on an attribute, it will only validate subsequent
+ * validators if the preceding validators have passed. When set to __false__, the validator
+ * will always be executed, even if its preceding validators are invalid.
+ *
+ * ```javascript
+ * // Examples
+ * buildValidations({
+ *  username: [
+ *    validator('presence', true),
+ *    validator('length', { min: 5 }),
+ *    validator('custom-promise-based-validator') // Will only be executed if the above two have passed
+ *  ]
+ * });
+ *
+ * validator('custom-validator-that-must-executed', {
+ *   lazy: false
+ * })
  * ```
  *
  * ### dependentKeys
@@ -47,9 +73,9 @@ const {
  *
  * ### disabled
  *
- * If set to `true`, disables the given validator. This option would usually go hand-in-hand
- * with {{#crossLinkModule 'Advanced Usage'}}options as functions{{/crossLinkModule}} and `dependentKeys`.
- * Defaults to `false`.
+ * Default: __false__
+ *
+ * If set to __true__, disables the given validator. 
  *
  * ```js
  * // Examples
@@ -59,14 +85,13 @@ const {
  * })
  * validator('presence', {
  *   presence: true,
- *   dependentKeys: ['shouldValidate'],
- *   disabled(model, attribute) {
- *     return !model.get('shouldValidate');
- *   }
+ *   disabled: computed.not('model.shouldValidate')
  * })
  * ```
  *
  * ### debounce
+ *
+ * Default: __0__
  *
  * Debounces the validation with the given time in `milliseconds`. All debounced validations will
  * be handled asynchronously (wrapped in a promise).
@@ -82,6 +107,8 @@ const {
  * ```
  *
  * ### isWarning
+ *
+ * Default: __false__
  *
  * Any validator can be declared as a warning validator by setting `isWarning` to true. These validators will act as
  * assertions that when return a message, will be placed under `warnings` and `warningMessages` collections. What this means,

--- a/addon/validators/belongs-to.js
+++ b/addon/validators/belongs-to.js
@@ -5,10 +5,10 @@
 
 import Ember from 'ember';
 import Base from 'ember-cp-validations/validators/base';
+import { isPromise } from 'ember-cp-validations/utils/utils';
 
 const {
-  get,
-  canInvoke
+  get
 } = Ember;
 
 
@@ -82,7 +82,7 @@ const {
 export default Base.extend({
   validate(value) {
     if (value) {
-      if (canInvoke(value, 'then')) {
+      if (isPromise(value)) {
         return value.then(model => model ? get(model, 'validations') : true);
       }
       return get(value, 'validations');

--- a/addon/validators/has-many.js
+++ b/addon/validators/has-many.js
@@ -3,12 +3,8 @@
  * Copyrights licensed under the New BSD License. See the accompanying LICENSE file for terms.
  */
 
-import Ember from 'ember';
 import Base from 'ember-cp-validations/validators/base';
-
-const {
-  canInvoke
-} = Ember;
+import { isPromise } from 'ember-cp-validations/utils/utils';
 
 /**
  *  Identifies a `has-many` relationship in an Ember Data Model or Ember.Object.
@@ -58,7 +54,7 @@ const {
 const HasMany = Base.extend({
   validate(value) {
     if (value) {
-      if (canInvoke(value, 'then')) {
+      if (isPromise(value)) {
         return value.then(models => models ? models.map(m => m.get('validations')) : true);
       }
       return value.map(m => m.get('validations'));

--- a/tests/dummy/app/models/user.js
+++ b/tests/dummy/app/models/user.js
@@ -29,14 +29,18 @@ var Validations = buildValidations({
         max: 10
       }),
       validator('format', {
-        regex: /^(?=.*\d)(?=.*[a-z])(?=.*[A-Z]).{4,8}$/,
+        regex: /^(?=.*\d)(?=.*[a-z])(?=.*[A-Z]).{4,10}$/,
         message: '{description} must include at least one upper case letter, one lower case letter, and a number'
+      }),
+      validator('inclusion', {
+        in: ['Pass123']
       }),
       validator('length', {
         isWarning: true,
         min: 6,
         message: 'What kind of weak password is that?'
-      })
+      }),
+      validator('number')
     ]
   },
   email: {

--- a/tests/dummy/app/models/user.js
+++ b/tests/dummy/app/models/user.js
@@ -32,15 +32,11 @@ var Validations = buildValidations({
         regex: /^(?=.*\d)(?=.*[a-z])(?=.*[A-Z]).{4,10}$/,
         message: '{description} must include at least one upper case letter, one lower case letter, and a number'
       }),
-      validator('inclusion', {
-        in: ['Pass123']
-      }),
       validator('length', {
         isWarning: true,
         min: 6,
         message: 'What kind of weak password is that?'
-      }),
-      validator('number')
+      })
     ]
   },
   email: {
@@ -57,7 +53,7 @@ var Validations = buildValidations({
   }),
   details: validator('belongs-to')
 }, {
-  debounce: 0
+  debounce: 500
 });
 
 export default DS.Model.extend(Validations, {

--- a/tests/dummy/app/models/user.js
+++ b/tests/dummy/app/models/user.js
@@ -53,7 +53,7 @@ var Validations = buildValidations({
   }),
   details: validator('belongs-to')
 }, {
-  debounce: 500
+  debounce: 0
 });
 
 export default DS.Model.extend(Validations, {

--- a/tests/integration/validations/factory-general-test.js
+++ b/tests/integration/validations/factory-general-test.js
@@ -212,12 +212,13 @@ test("shallow isAsync test", function(assert) {
   var obj = setupObject(this, Ember.Object.extend(Validations));
 
   assert.equal(obj.get('validations.attrs.firstName.isAsync'), true);
-  assert.equal(Ember.canInvoke(obj.get('validations.attrs.firstName.value'), 'then'), true);
+  assert.equal(obj.get('validations.attrs.firstName.isValidating'), true);
 
   return obj.validate().then(({
     model
   }) => {
     assert.equal(model.get('validations.isValid'), true);
+    assert.equal(model.get('validations.isValidating'), false);
   });
 });
 

--- a/tests/integration/validations/factory-general-test.js
+++ b/tests/integration/validations/factory-general-test.js
@@ -893,3 +893,90 @@ test("options CP changes trigger attribute revalidation", function(assert) {
   assert.equal(object.get('validations.attrs.firstName.isValid'), true);
   assert.equal(object.get('validations.isValid'), true, 'isValid was expected to be FALSE');
 });
+
+test("lazy validators are actually lazy", function(assert) {
+  this.register('validator:length', LengthValidator);
+  this.register('validator:presence', PresenceValidator);
+
+  var customValidatorCount = 0;
+
+  var Validations = buildValidations({
+    password: {
+      description: 'Password',
+      validators: [
+        validator('presence', true),
+        validator('length', {
+          min: 5,
+        }),
+        validator(() => {
+          customValidatorCount++;
+          return 'Password is not valid';
+        })
+      ]
+    }
+  });
+
+  var object = setupObject(this, Ember.Object.extend(Validations));
+
+  assert.equal(object.get('validations.attrs.password.isValid'), false);
+  assert.equal(object.get('validations.attrs.password.messages.length'), 1, 'Only 1 error message should be present');
+  assert.equal(object.get('validations.attrs.password.message'), 'Password can\'t be blank');
+
+  object.set('password', '1234');
+
+  assert.equal(object.get('validations.attrs.password.isValid'), false);
+  assert.equal(object.get('validations.attrs.password.messages.length'), 1, 'Only 1 error message should be present');
+  assert.equal(object.get('validations.attrs.password.message'), 'Password is too short (minimum is 5 characters)');
+
+  object.set('password', '12345');
+
+  assert.equal(object.get('validations.attrs.password.isValid'), false);
+  assert.equal(object.get('validations.attrs.password.messages.length'), 1, 'Only 1 error message should be present');
+  assert.equal(object.get('validations.attrs.password.message'), 'Password is not valid');
+  assert.equal(customValidatorCount, 1, 'Last validator only executed once');
+});
+
+test("none lazy validators are actually not lazy", function(assert) {
+  this.register('validator:length', LengthValidator);
+  this.register('validator:presence', PresenceValidator);
+
+  var customValidatorCount = 0;
+
+  var Validations = buildValidations({
+    password: {
+      description: 'Password',
+      validators: [
+        validator('presence', true),
+        validator('length', {
+          min: 5,
+          lazy: false
+        }),
+        validator(() => {
+          customValidatorCount++;
+          return 'Password is not valid';
+        }, {
+          lazy: false
+        })
+      ]
+    }
+  });
+
+  var object = setupObject(this, Ember.Object.extend(Validations));
+
+  assert.equal(object.get('validations.attrs.password.isValid'), false);
+  assert.equal(object.get('validations.attrs.password.messages.length'), 2, 'Only 2 error message should be present');
+  assert.equal(object.get('validations.attrs.password.message'), 'Password can\'t be blank');
+
+  object.set('password', '1234');
+
+  assert.equal(object.get('validations.attrs.password.isValid'), false);
+  assert.equal(object.get('validations.attrs.password.messages.length'), 2, 'Only 2 error message should be present');
+  assert.equal(object.get('validations.attrs.password.message'), 'Password is too short (minimum is 5 characters)');
+
+  object.set('password', '12345');
+
+  assert.equal(object.get('validations.attrs.password.isValid'), false);
+  assert.equal(object.get('validations.attrs.password.messages.length'), 1, 'Only 1 error message should be present');
+  assert.equal(object.get('validations.attrs.password.message'), 'Password is not valid');
+  assert.equal(customValidatorCount, 3, 'Last validator executed 3 times');
+});

--- a/tests/integration/validations/model-relationships-test.js
+++ b/tests/integration/validations/model-relationships-test.js
@@ -391,7 +391,7 @@ test("alias validation - firstMessageOnly", function(assert) {
       alias: 'firstName',
       firstMessageOnly: true
     })
-  })));
+  }, { lazy: false })));
 
   user.get('validations').validateSync();
 
@@ -414,7 +414,7 @@ test("alias validation - multiple", function(assert) {
       validator('alias', 'firstName'),
       validator('alias', 'lastName')
     ]
-  })));
+  }, { lazy: false })));
 
   user.get('validations').validateSync();
 

--- a/tests/unit/validators/dependent-test.js
+++ b/tests/unit/validators/dependent-test.js
@@ -56,7 +56,7 @@ test('all empty attributes', function(assert) {
   message = Validator.validate(undefined, builtOptions.copy(), model);
 
   assert.equal(message, "This field is invalid");
-  assert.equal(get(model, 'validations.messages.length'), 2);
+  assert.equal(get(model, 'validations.messages.length'), 1);
   assert.equal(get(model, 'validations.isValid'), false);
 });
 


### PR DESCRIPTION
Resolves #320.

Changes proposed:

 - Lazily run validations if possible
   - Exposes `lazy` common option which defaults to **true**
   - Will only work with sync validations

Tasks:

- [x] Added test case(s)
- [x] Updated documentation

