### PR TITLE
fixing input red borders in dummy app

### DIFF
--- a/tests/dummy/app/components/validated-input.js
+++ b/tests/dummy/app/components/validated-input.js
@@ -35,7 +35,7 @@ export default Ember.Component.extend({
   hasContent: computed.notEmpty('value'),
   isValid: computed.and('hasContent', 'validation.isValid', 'notValidating'),
   isInvalid: computed.oneWay('validation.isInvalid'),
-  showErrorClass: computed.and('notValidating', 'showMessage', 'hasContent', 'validation'),
+  showErrorClass: computed.and('notValidating', 'showErrorMessage', 'hasContent', 'validation'),
   showErrorMessage: computed('validation.isDirty', 'isInvalid', 'didValidate', function() {
     return (this.get('validation.isDirty') || this.get('didValidate')) && this.get('isInvalid');
   }),


### PR DESCRIPTION
Resolves # .
In the component `validated-input`, the property `showErrorClass` was checking an undefined property (`showMessage`) which always makes it false and the component never got the `has-error` class, preventing the border of the input to turn red.

Changes proposed:
 - Changed `showMessage` for `showErrorMessage` in [#L38](https://github.com/offirgolan/ember-cp-validations/blob/master/tests/dummy/app/components/validated-input.js#L38) of the component `validated-input`.

