### PR TITLE
[BugFix] Define CPs and nested CPs in attrs object once per class

### DIFF
--- a/tests/integration/validations/factory-general-test.js
+++ b/tests/integration/validations/factory-general-test.js
@@ -653,6 +653,12 @@ test("nested keys - complex", function(assert) {
   assert.ok(object.get('validations.attrs.user.foo._model'));
 
   assert.equal(object.get('validations.isValid'), true);
+
+  run(() => object.destroy());
+
+  assert.notOk(object.get('validations.attrs._model'));
+  assert.notOk(object.get('validations.attrs.user.foo.bar._model'));
+  assert.notOk(object.get('validations.attrs.user.foo._model'));
 });
 
 test("nested keys - inheritance", function(assert) {


### PR DESCRIPTION
In the current implementation, we are using `defineProperty` to add CPs and nested object CPs in the `init` method of the attrs object creation. This is extremely slow and runs on a **per instance** basis. 

This PR removes the need for that by creating a tree of nested classes while applying the CPs on their protos. Once the attrs class is created, it instantiates those classes. 