### PR TITLE
Add validator type to error messages

### DIFF
--- a/addon/validations/error.js
+++ b/addon/validations/error.js
@@ -6,6 +6,19 @@ import Ember from 'ember';
  */
 
 export default Ember.Object.extend({
+  /**
+   * The error validator type
+   * @property type
+   * @type {String}
+   */
+  type: null,
+
+  /**
+   * The error message
+   * @property message
+   * @type {String}
+   */
+  message: null,
 
   /**
    * The attribute that the error belongs to
@@ -19,12 +32,5 @@ export default Ember.Object.extend({
    * @property parentAttribute
    * @type {String}
    */
-  parentAttribute: null,
-
-  /**
-   * The error message
-   * @property message
-   * @type {String}
-   */
-  message: null
+  parentAttribute: null
 });

--- a/addon/validations/internal-result-object.js
+++ b/addon/validations/internal-result-object.js
@@ -25,6 +25,7 @@ export default Ember.Object.extend({
   model: null,
   isValid: true,
   isValidating: false,
+  type: null,
   message: null,
   attribute: '',
 
@@ -72,9 +73,10 @@ export default Ember.Object.extend({
     return makeArray(get(this, 'message'));
   }),
 
-  error: computed('message', 'isInvalid', 'attribute', function () {
+  error: computed('isInvalid', 'type', 'message', 'attribute', function () {
     if (get(this, 'isInvalid')) {
       return ValidationError.create({
+        type: get(this, 'type'),
         message: get(this, 'message'),
         attribute: get(this, 'attribute')
       });

--- a/addon/validations/internal-result-object.js
+++ b/addon/validations/internal-result-object.js
@@ -25,7 +25,7 @@ export default Ember.Object.extend({
   model: null,
   isValid: true,
   isValidating: false,
-  type: null,
+  type: computed.readOnly('_validator._type'),
   message: null,
   attribute: '',
 

--- a/addon/validations/result-collection.js
+++ b/addon/validations/result-collection.js
@@ -360,7 +360,7 @@ export default Ember.ArrayProxy.extend({
    * @type {Array}
    * @private
    */
-   _errorContent: computed.filterBy('content', 'isWarning', false).readOnly(),
+  _errorContent: computed.filterBy('content', 'isWarning', false).readOnly(),
 
   /**
    * @property _warningContent

--- a/addon/validations/result.js
+++ b/addon/validations/result.js
@@ -159,7 +159,6 @@ const Result = Ember.Object.extend({
    */
   _validations: computed('model', 'attribute', '_promise', '_validator', function () {
     return InternalResultObject.extend({
-      type: computed.readOnly('_validator._type'),
       attrValue: computed.readOnly(`model.${get(this, 'attribute')}`)
     }).create(getProperties(this, ['model', 'attribute', '_promise', '_validator']));
   }),

--- a/addon/validations/result.js
+++ b/addon/validations/result.js
@@ -159,6 +159,7 @@ const Result = Ember.Object.extend({
    */
   _validations: computed('model', 'attribute', '_promise', '_validator', function () {
     return InternalResultObject.extend({
+      type: computed.readOnly('_validator._type'),
       attrValue: computed.readOnly(`model.${get(this, 'attribute')}`)
     }).create(getProperties(this, ['model', 'attribute', '_promise', '_validator']));
   }),

--- a/tests/integration/validations/factory-general-test.js
+++ b/tests/integration/validations/factory-general-test.js
@@ -989,21 +989,26 @@ test("none lazy validators are actually not lazy", function(assert) {
 
 test("validator should return correct error type", function(assert) {
   this.register('validator:presence', PresenceValidator);
+  this.register('validator:length', LengthValidator);
 
   var Validations = buildValidations({
-    fullName: [
-      validator('presence', true)
+    firstName: [
+      validator('presence', true),
+      validator('length', {min: 5, max: 35})
+    ],
+    lastName: [
+      validator('presence', true),
+      validator('length', {min: 5, max: 35})
     ]
   });
 
   var obj = setupObject(this, Ember.Object.extend(Validations), {
-    fullName: 'Offir Golan'
+    firstName: 'Foo',
+    lastName: null
   });
 
-  assert.equal(obj.get('validations.attrs.fullName.isValid'), true, 'isValid was expected to be TRUE');
-
-  obj.set('fullName', null);
-
-  assert.equal(obj.get('validations.attrs.fullName.isValid'), false, 'isValid was expected to be FALSE');
-  assert.equal(obj.get('validations.attrs.fullName.error.type'), 'presence', 'error type was expected to be `presence`');
+  assert.equal(obj.get('validations.attrs.firstName.isValid'), false, 'isValid was expected to be FALSE');
+  assert.equal(obj.get('validations.attrs.lastName.error.type'), 'presence', 'error type was expected to be `presence`');
+  assert.equal(obj.get('validations.errors.length'), 2, 'number of errors was expected to be 2');
+  assert.equal(obj.get('validations.errors').filterBy('type', 'presence').length, 1, 'number of errors was expected to be 1');
 });

--- a/tests/integration/validations/factory-general-test.js
+++ b/tests/integration/validations/factory-general-test.js
@@ -986,3 +986,24 @@ test("none lazy validators are actually not lazy", function(assert) {
   assert.equal(object.get('validations.attrs.password.message'), 'Password is not valid');
   assert.equal(customValidatorCount, 3, 'Last validator executed 3 times');
 });
+
+test("validator should return correct error type", function(assert) {
+  this.register('validator:presence', PresenceValidator);
+
+  var Validations = buildValidations({
+    fullName: [
+      validator('presence', true)
+    ]
+  });
+
+  var obj = setupObject(this, Ember.Object.extend(Validations), {
+    fullName: 'Offir Golan'
+  });
+
+  assert.equal(obj.get('validations.attrs.fullName.isValid'), true, 'isValid was expected to be TRUE');
+
+  obj.set('fullName', null);
+
+  assert.equal(obj.get('validations.attrs.fullName.isValid'), false, 'isValid was expected to be FALSE');
+  assert.equal(obj.get('validations.attrs.fullName.error.type'), 'presence', 'error type was expected to be `presence`');
+});


### PR DESCRIPTION
Changes proposed:

 - Add validator type to error messages. It can be helpful if you're checking if there's a specific type of error in the collection.

Tasks:

- [x] Added test case(s)
- [x] Updated documentation

```js
model.get('validations.errors').filterBy('type', 'unique-email');

// [ { type: 'presence',
//     message: 'This field can\'t be blank',
//     attribute: 'lastName' } ]
```

```js
model.get('validations.errors');

// [ { type: 'length',
//     message: 'This field is too short (minimum is 5 characters)',
//     attribute: 'firstName' },
//   { type: 'presence',
//     message: 'This field can\'t be blank',
//     attribute: 'lastName' } ]
```

```js
Validations = buildValidations({
  firstName: [
    validator('presence', true),
    validator('length', {min: 5, max: 35})
  ],
  lastName: [
    validator('presence', true),
    validator('length', {min: 5, max: 35})
  ]
});
```

```js
Ember.Object.extend(Validations), {
  firstName: 'Foo',
  lastName: null
});
```