### PR TITLE
Allow for requirejs.has to not be available

### DIFF
--- a/addon/utils/utils.js
+++ b/addon/utils/utils.js
@@ -15,7 +15,14 @@ const {
 } = Ember;
 
 export function requireModule(module) {
-  return self.requirejs.has(module) ? self.require(module).default : undefined;
+  const rjs = self.requirejs;
+
+  if (
+    (rjs.has && rjs.has(module)) ||
+    (!rjs.has && (rjs.entries[module] || rjs.entries[module + '/index']))
+  ) {
+    return self.require(module).default;
+  }
 }
 
 export function unwrapString(s) {


### PR DESCRIPTION
We spoke about this on slack a week back, older versions of the loader do not support the `has` API.