### PR TITLE
DEPRECATION: Ember.Handlebars.SafeString is deprecated in favor of Ember.String.htmlSafe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,30 @@
 Changelog
 =========
 
+## v3.0.0
+
+- [#226](https://github.com/offirgolan/ember-cp-validations/pull/226) Warning Validators
+- [#232](https://github.com/offirgolan/ember-cp-validations/pull/232) Computed Options (special thanks to [@xcambar](https://github.com/xcambar))
+- [#239](https://github.com/offirgolan/ember-cp-validations/pull/239) Use Require for Checking Ember Data
+- [#240](https://github.com/offirgolan/ember-cp-validations/pull/240) DS Error Validator + Nested Keys
+- [#241](https://github.com/offirgolan/ember-cp-validations/pull/241) Fix blueprint warning
+- [#245](https://github.com/offirgolan/ember-cp-validations/pull/245) Utilize \_\_root\_\_ in validator blueprint
+- [#249](https://github.com/offirgolan/ember-cp-validations/pull/249) Fixed email regex of format validator [@simonihmig](https://github.com/simonihmig)
+- [#252](https://github.com/offirgolan/ember-cp-validations/pull/252) Fix require module
+- [#262](https://github.com/offirgolan/ember-cp-validations/pull/262) Use `model` instead of `_model` when declaring custom dependents
+- [#266](https://github.com/offirgolan/ember-cp-validations/pull/266) Check for null in extractOptionsDependentKeys [@xcambar](https://github.com/xcambar)
+- [#272](https://github.com/offirgolan/ember-cp-validations/pull/272) Fix ember-cli deprecation warning
+- [#294](https://github.com/offirgolan/ember-cp-validations/pull/294) [BUGFIX] Validate promise resolves even when validations are still validating
+- [#305](https://github.com/offirgolan/ember-cp-validations/pull/305) [BUGFIX] Provide `baseDir` to allow for proper caching
+- [#311](https://github.com/offirgolan/ember-cp-validations/pull/311) [FEATURE] Place mixin under a named scope for Ember Inspector
+- [#312](https://github.com/offirgolan/ember-cp-validations/pull/312) [BUGFIX] Deleted DS.Model records should be suppressed
+- [#321](https://github.com/offirgolan/ember-cp-validations/pull/321) [FEATURE] Lazily run validations
+- [#330](https://github.com/offirgolan/ember-cp-validations/pull/330) [FEATURE] Add option `allowNonTld` for email format validator [@indr](https://github.com/indr)
+- [#333](https://github.com/offirgolan/ember-cp-validations/pull/333) [BUGFIX] Define CPs and nested CPs in attrs object once per class
+- [#338](https://github.com/offirgolan/ember-cp-validations/pull/338) [FEATURE] Add validator type to error messages [@kepek](https://github.com/kepek)
+- [#339](https://github.com/offirgolan/ember-cp-validations/pull/339) [BUGFIX] Allow for requirejs.has to not be available [@jasonmit](https://github.com/jasonmit)
+
+
 ## v3.0.0-beta.7
 
 - [#330](https://github.com/offirgolan/ember-cp-validations/pull/330) [FEATURE] Add option `allowNonTld` for email format validator [@indr](https://github.com/indr)

--- a/addon/utils/utils.js
+++ b/addon/utils/utils.js
@@ -4,6 +4,7 @@
  */
 
 import Ember from 'ember';
+import isHTMLSafe from 'ember-string-ishtmlsafe-polyfill';
 
 const DS = requireModule('ember-data');
 
@@ -19,7 +20,7 @@ export function requireModule(module) {
 }
 
 export function unwrapString(s) {
-  if (s && s instanceof Ember.Handlebars.SafeString) {
+  if (isHTMLSafe(s)) {
     return s.toString();
   }
 

--- a/addon/utils/utils.js
+++ b/addon/utils/utils.js
@@ -16,7 +16,14 @@ const {
 } = Ember;
 
 export function requireModule(module) {
-  return self.requirejs.has(module) ? self.require(module).default : undefined;
+  const rjs = self.requirejs;
+
+  if (
+    (rjs.has && rjs.has(module)) ||
+    (!rjs.has && (rjs.entries[module] || rjs.entries[module + '/index']))
+  ) {
+    return self.require(module).default;
+  }
 }
 
 export function unwrapString(s) {

--- a/addon/validations/error.js
+++ b/addon/validations/error.js
@@ -6,6 +6,19 @@ import Ember from 'ember';
  */
 
 export default Ember.Object.extend({
+  /**
+   * The error validator type
+   * @property type
+   * @type {String}
+   */
+  type: null,
+
+  /**
+   * The error message
+   * @property message
+   * @type {String}
+   */
+  message: null,
 
   /**
    * The attribute that the error belongs to
@@ -19,12 +32,5 @@ export default Ember.Object.extend({
    * @property parentAttribute
    * @type {String}
    */
-  parentAttribute: null,
-
-  /**
-   * The error message
-   * @property message
-   * @type {String}
-   */
-  message: null
+  parentAttribute: null
 });

--- a/addon/validations/internal-result-object.js
+++ b/addon/validations/internal-result-object.js
@@ -25,6 +25,7 @@ export default Ember.Object.extend({
   model: null,
   isValid: true,
   isValidating: false,
+  type: null,
   message: null,
   attribute: '',
 
@@ -72,9 +73,10 @@ export default Ember.Object.extend({
     return makeArray(get(this, 'message'));
   }),
 
-  error: computed('message', 'isInvalid', 'attribute', function () {
+  error: computed('isInvalid', 'type', 'message', 'attribute', function () {
     if (get(this, 'isInvalid')) {
       return ValidationError.create({
+        type: get(this, 'type'),
         message: get(this, 'message'),
         attribute: get(this, 'attribute')
       });

--- a/addon/validations/internal-result-object.js
+++ b/addon/validations/internal-result-object.js
@@ -25,7 +25,7 @@ export default Ember.Object.extend({
   model: null,
   isValid: true,
   isValidating: false,
-  type: null,
+  type: computed.readOnly('_validator._type'),
   message: null,
   attribute: '',
 

--- a/addon/validations/result-collection.js
+++ b/addon/validations/result-collection.js
@@ -360,7 +360,7 @@ export default Ember.ArrayProxy.extend({
    * @type {Array}
    * @private
    */
-   _errorContent: computed.filterBy('content', 'isWarning', false).readOnly(),
+  _errorContent: computed.filterBy('content', 'isWarning', false).readOnly(),
 
   /**
    * @property _warningContent

--- a/addon/validations/result.js
+++ b/addon/validations/result.js
@@ -159,7 +159,6 @@ const Result = Ember.Object.extend({
    */
   _validations: computed('model', 'attribute', '_promise', '_validator', function () {
     return InternalResultObject.extend({
-      type: computed.readOnly('_validator._type'),
       attrValue: computed.readOnly(`model.${get(this, 'attribute')}`)
     }).create(getProperties(this, ['model', 'attribute', '_promise', '_validator']));
   }),

--- a/addon/validations/result.js
+++ b/addon/validations/result.js
@@ -159,6 +159,7 @@ const Result = Ember.Object.extend({
    */
   _validations: computed('model', 'attribute', '_promise', '_validator', function () {
     return InternalResultObject.extend({
+      type: computed.readOnly('_validator._type'),
       attrValue: computed.readOnly(`model.${get(this, 'attribute')}`)
     }).create(getProperties(this, ['model', 'attribute', '_promise', '_validator']));
   }),

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ember-cp-validations",
-  "version": "3.0.0-beta.7",
+  "version": "3.0.0",
   "description": "Ember computed property based validations",
   "directories": {
     "doc": "doc",

--- a/package.json
+++ b/package.json
@@ -64,7 +64,6 @@
     "ember-load-initializers": "^0.5.1",
     "ember-moment": "6.1.0",
     "ember-resolver": "^2.0.3",
-    "ember-string-ishtmlsafe-polyfill": "1.0.1",
     "ember-truth-helpers": "1.2.0",
     "loader.js": "^4.0.11",
     "moment": "2.14.1",

--- a/package.json
+++ b/package.json
@@ -82,6 +82,7 @@
     "ember-cli-babel": "^5.1.8",
     "ember-cli-version-checker": "^1.1.4",
     "ember-getowner-polyfill": "^1.0.1",
+    "ember-string-ishtmlsafe-polyfill": "1.0.1",
     "exists-sync": "0.0.3",
     "walk-sync": "^0.3.1"
   },

--- a/package.json
+++ b/package.json
@@ -64,6 +64,7 @@
     "ember-load-initializers": "^0.5.1",
     "ember-moment": "6.1.0",
     "ember-resolver": "^2.0.3",
+    "ember-string-ishtmlsafe-polyfill": "1.0.1",
     "ember-truth-helpers": "1.2.0",
     "loader.js": "^4.0.11",
     "moment": "2.14.1",

--- a/tests/integration/validations/factory-general-test.js
+++ b/tests/integration/validations/factory-general-test.js
@@ -989,21 +989,26 @@ test("none lazy validators are actually not lazy", function(assert) {
 
 test("validator should return correct error type", function(assert) {
   this.register('validator:presence', PresenceValidator);
+  this.register('validator:length', LengthValidator);
 
   var Validations = buildValidations({
-    fullName: [
-      validator('presence', true)
+    firstName: [
+      validator('presence', true),
+      validator('length', {min: 5, max: 35})
+    ],
+    lastName: [
+      validator('presence', true),
+      validator('length', {min: 5, max: 35})
     ]
   });
 
   var obj = setupObject(this, Ember.Object.extend(Validations), {
-    fullName: 'Offir Golan'
+    firstName: 'Foo',
+    lastName: null
   });
 
-  assert.equal(obj.get('validations.attrs.fullName.isValid'), true, 'isValid was expected to be TRUE');
-
-  obj.set('fullName', null);
-
-  assert.equal(obj.get('validations.attrs.fullName.isValid'), false, 'isValid was expected to be FALSE');
-  assert.equal(obj.get('validations.attrs.fullName.error.type'), 'presence', 'error type was expected to be `presence`');
+  assert.equal(obj.get('validations.attrs.firstName.isValid'), false, 'isValid was expected to be FALSE');
+  assert.equal(obj.get('validations.attrs.lastName.error.type'), 'presence', 'error type was expected to be `presence`');
+  assert.equal(obj.get('validations.errors.length'), 2, 'number of errors was expected to be 2');
+  assert.equal(obj.get('validations.errors').filterBy('type', 'presence').length, 1, 'number of errors was expected to be 1');
 });

--- a/tests/integration/validations/factory-general-test.js
+++ b/tests/integration/validations/factory-general-test.js
@@ -986,3 +986,24 @@ test("none lazy validators are actually not lazy", function(assert) {
   assert.equal(object.get('validations.attrs.password.message'), 'Password is not valid');
   assert.equal(customValidatorCount, 3, 'Last validator executed 3 times');
 });
+
+test("validator should return correct error type", function(assert) {
+  this.register('validator:presence', PresenceValidator);
+
+  var Validations = buildValidations({
+    fullName: [
+      validator('presence', true)
+    ]
+  });
+
+  var obj = setupObject(this, Ember.Object.extend(Validations), {
+    fullName: 'Offir Golan'
+  });
+
+  assert.equal(obj.get('validations.attrs.fullName.isValid'), true, 'isValid was expected to be TRUE');
+
+  obj.set('fullName', null);
+
+  assert.equal(obj.get('validations.attrs.fullName.isValid'), false, 'isValid was expected to be FALSE');
+  assert.equal(obj.get('validations.attrs.fullName.error.type'), 'presence', 'error type was expected to be `presence`');
+});


### PR DESCRIPTION
```DEPRECATION: Ember.Handlebars.SafeString is deprecated in favor of Ember.String.htmlSafe [deprecation id: ember-htmlbars.ember-handlebars-safestring] See http://emberjs.com/deprecations/v2.x#toc_use-ember-string-htmlsafe-over-ember-handlebars-safestring for more details.```

Changes proposed:
 - Add `ember-string-ishtmlsafe-polyfill` to keep backwards compatibility.

Tasks:
- N/A
