### PR TITLE
DEPRECATION: Ember.Handlebars.SafeString

### DIFF
--- a/addon/utils/utils.js
+++ b/addon/utils/utils.js
@@ -4,6 +4,7 @@
  */
 
 import Ember from 'ember';
+import isHTMLSafe from 'ember-string-ishtmlsafe-polyfill';
 
 const DS = requireModule('ember-data');
 
@@ -26,7 +27,7 @@ export function requireModule(module) {
 }
 
 export function unwrapString(s) {
-  if (s && s instanceof Ember.Handlebars.SafeString) {
+  if (isHTMLSafe(s)) {
     return s.toString();
   }
 

--- a/package.json
+++ b/package.json
@@ -82,6 +82,7 @@
     "ember-cli-babel": "^5.1.8",
     "ember-cli-version-checker": "^1.1.4",
     "ember-getowner-polyfill": "^1.0.1",
+    "ember-string-ishtmlsafe-polyfill": "1.0.1",
     "exists-sync": "0.0.3",
     "walk-sync": "^0.3.1"
   },


### PR DESCRIPTION
```DEPRECATION: Ember.Handlebars.SafeString is deprecated in favor of Ember.String.htmlSafe [deprecation id: ember-htmlbars.ember-handlebars-safestring] See http://emberjs.com/deprecations/v2.x#toc_use-ember-string-htmlsafe-over-ember-handlebars-safestring for more details.```

Changes proposed:
 - Add polyfill for `Ember.Handlebars.SafeString` to keep backwards compatibility.

Tasks:
- N/A
