### PR TITLE
DEPRECATION: Ember.Handlebars.SafeString

### DIFF
--- a/addon/utils/utils.js
+++ b/addon/utils/utils.js
@@ -4,6 +4,7 @@
  */
 
 import Ember from 'ember';
+import isHTMLSafe from 'ember-string-ishtmlsafe-polyfill';
 
 export function requireModule(module) {
   const rjs = self.requirejs;
@@ -17,7 +18,7 @@ export function requireModule(module) {
 }
 
 export function unwrapString(input) {
-  if (input && input instanceof Ember.Handlebars.SafeString) {
+  if (isHTMLSafe(input)) {
     return input.toString();
   }
 

--- a/package.json
+++ b/package.json
@@ -76,6 +76,7 @@
     "ember-cli-babel": "^5.1.6",
     "ember-cli-version-checker": "^1.1.4",
     "ember-getowner-polyfill": "^1.0.1",
+    "ember-string-ishtmlsafe-polyfill": "1.0.1",
     "exists-sync": "0.0.3",
     "walk-sync": "^0.2.0"
   },


### PR DESCRIPTION
Changes proposed:

 - Backports the fix from #344 to the 2.x branch for users still on that

(unsure if my changes are what is causing CI to fail or not)