### PR TITLE
[BUGFIX] When the path is empty, use `this` for createAttrsClass

### DIFF
--- a/addon/validations/factory.js
+++ b/addon/validations/factory.js
@@ -303,7 +303,8 @@ function createAttrsClass(validatableAttributes, validationRules, owner) {
       validatableAttributes.forEach(attribute => {
         // Add a reference to the model in the deepest object
         const path = attribute.split('.');
-        const lastObject = get(this, path.slice(0, path.length - 1).join('.'));
+        const pathFragment = path.slice(0, path.length - 1).join('.');
+        const lastObject = isEmpty(pathFragment) ? this : get(this, pathFragment);
 
         if (isNone(get(lastObject, '_model'))) {
           set(lastObject, '_model', model);
@@ -316,7 +317,8 @@ function createAttrsClass(validatableAttributes, validationRules, owner) {
       validatableAttributes.forEach(attribute => {
         // Remove model reference from nested objects
         const path = attribute.split('.');
-        const lastObject = get(this, path.slice(0, path.length - 1).join('.'));
+        const pathFragment = path.slice(0, path.length - 1).join('.');
+        const lastObject = isEmpty(pathFragment) ? this : get(this, pathFragment);
 
         if (!isNone(get(lastObject, '_model'))) {
           set(lastObject, '_model', null);


### PR DESCRIPTION
#Resolves regression in Ember 2.10.0-beta.*.

Currently lastObject is undefined and results in Ember.get(lastObject, ...) to throw with cannot get on undefined.

Changes proposed:

 - Ember.get no longer will return the first argument when you pass an empty string as the key/path
 - When you pass an empty string, return `this` like the original behavior

