### PR TITLE
[BUGFIX] Resolve _type conflicts with EmberValidator classes

### DIFF
--- a/addon/-private/ember-validator.js
+++ b/addon/-private/ember-validator.js
@@ -3,7 +3,7 @@ import { validate as _validate } from 'ember-validators';
 
 export default Base.extend({
   validate() {
-    let result = _validate(this.get('_type'), ...arguments);
+    let result = _validate(this.get('_evType'), ...arguments);
 
     if (result && typeof result === 'object') {
       return this.createErrorMessage(result.type, result.value, result.context);

--- a/addon/validators/alias.js
+++ b/addon/validators/alias.js
@@ -35,8 +35,6 @@ const {
  *  @extends Base
  */
 const Alias = Base.extend({
-  _type: 'alias',
-
   /**
    * Normalized options passed in.
    * ```js

--- a/addon/validators/belongs-to.js
+++ b/addon/validators/belongs-to.js
@@ -81,8 +81,6 @@ const {
  *  @extends Base
  */
 const BelongsTo = Base.extend({
-  _type: 'belongs-to',
-
   validate(value) {
     if (value) {
       if (isPromise(value)) {

--- a/addon/validators/collection.js
+++ b/addon/validators/collection.js
@@ -32,7 +32,7 @@ const {
  *  @extends Base
  */
 const Collection = EmberValidator.extend({
-  _type: 'collection',
+  _evType: 'collection',
 
   /**
    * Normalized options passed in.

--- a/addon/validators/confirmation.js
+++ b/addon/validators/confirmation.js
@@ -33,7 +33,7 @@ const {
  *  @extends Base
  */
 const Confirmation = EmberValidator.extend({
-  _type: 'confirmation'
+  _evType: 'confirmation'
 });
 
 Confirmation.reopenClass({

--- a/addon/validators/date.js
+++ b/addon/validators/date.js
@@ -31,5 +31,5 @@ import EmberValidator from 'ember-cp-validations/-private/ember-validator';
  *  @extends Base
  */
 export default EmberValidator.extend({
-  _type: 'date'
+  _evType: 'date'
 });

--- a/addon/validators/dependent.js
+++ b/addon/validators/dependent.js
@@ -37,8 +37,6 @@ const {
  *  @extends Base
  */
 const Dependent = Base.extend({
-  _type: 'dependent',
-
   /**
    * @method validate
    * @param {Any} value

--- a/addon/validators/ds-error.js
+++ b/addon/validators/ds-error.js
@@ -23,7 +23,7 @@ import { getPathAndKey } from 'ember-validators/ds-error';
  *  @extends Base
  */
 const DSError = EmberValidator.extend({
-  _type: 'ds-error'
+  _evType: 'ds-error'
 });
 
 DSError.reopenClass({

--- a/addon/validators/exclusion.js
+++ b/addon/validators/exclusion.js
@@ -26,5 +26,5 @@ import EmberValidator from 'ember-cp-validations/-private/ember-validator';
  *  @extends Base
  */
 export default EmberValidator.extend({
-  _type: 'exclusion'
+  _evType: 'exclusion'
 });

--- a/addon/validators/format.js
+++ b/addon/validators/format.js
@@ -53,7 +53,7 @@ const {
  *  @extends Base
  */
 export default EmberValidator.extend({
-  _type: 'format',
+  _evType: 'format',
   regularExpressions,
 
   /**

--- a/addon/validators/has-many.js
+++ b/addon/validators/has-many.js
@@ -54,8 +54,6 @@ import { isPromise } from 'ember-cp-validations/utils/utils';
  *  @extends Base
  */
 const HasMany = Base.extend({
-  _type: 'has-many',
-
   validate(value) {
     if (value) {
       if (isPromise(value)) {

--- a/addon/validators/inclusion.js
+++ b/addon/validators/inclusion.js
@@ -41,5 +41,5 @@ import EmberValidator from 'ember-cp-validations/-private/ember-validator';
  *  @extends Base
  */
 export default EmberValidator.extend({
-  _type: 'inclusion'
+  _evType: 'inclusion'
 });

--- a/addon/validators/length.js
+++ b/addon/validators/length.js
@@ -33,7 +33,7 @@ const {
  *  @extends Base
  */
 export default EmberValidator.extend({
-  _type: 'length',
+  _evType: 'length',
 
   /**
    * Default allowNone to true

--- a/addon/validators/number.js
+++ b/addon/validators/number.js
@@ -27,5 +27,5 @@ import EmberValidator from 'ember-cp-validations/-private/ember-validator';
  *  @extends Base
  */
 export default EmberValidator.extend({
-  _type: 'number'
+  _evType: 'number'
 });

--- a/addon/validators/presence.js
+++ b/addon/validators/presence.js
@@ -32,7 +32,7 @@ import EmberValidator from 'ember-cp-validations/-private/ember-validator';
  *  @extends Base
  */
 export default EmberValidator.extend({
-  _type: 'presence',
+  _evType: 'presence',
 
   /**
    * Normalized options passed in.


### PR DESCRIPTION
Resolves #386  .

Changes proposed:

 - Using the _type property on the validator to identify EV type was getting overridden by custom validators that were extending them. This fix uses a dedicated private property instead.