### PR TITLE
Adding canceling of debounced validations

### DIFF
--- a/addon/validations/factory.js
+++ b/addon/validations/factory.js
@@ -476,7 +476,9 @@ function generateValidationResultsFor(attribute, model, validators, validate, op
         let t = run.debounce(validator, resolve, debounce, false);
 
         if (!opts.disableDebounceCache) {
-          cache[guidFor(validator)] = t;
+          let guid = guidFor(validator);
+          Ember.run.cancel(cache[guid])
+          cache[guid] = t;
         }
       }).then(() => {
         return validate(validator, get(validator, 'options').copy());

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "ember-cli-inject-live-reload": "^1.4.1",
     "ember-cli-jshint": "^2.0.1",
     "ember-cli-less": "1.5.3",
-    "ember-cli-moment-shim": "3.0.0",
+    "ember-cli-moment-shim": "2.2.1",
     "ember-cli-qunit": "^3.0.0",
     "ember-cli-release": "1.0.0-beta.2",
     "ember-cli-sri": "^2.1.1",
@@ -61,14 +61,14 @@
     "ember-disable-prototype-extensions": "^1.1.0",
     "ember-export-application-global": "^1.0.5",
     "ember-font-awesome": "2.2.0",
-    "ember-load-initializers": "^0.6.3",
-    "ember-moment": "7.0.3",
+    "ember-load-initializers": "^0.5.1",
+    "ember-moment": "6.1.0",
     "ember-resolver": "^2.0.3",
     "ember-suave": "4.0.1",
     "ember-truth-helpers": "1.2.0",
     "loader.js": "^4.0.11",
-    "moment": "2.17.1",
-    "moment-timezone": "0.5.10",
+    "moment": "2.16.0",
+    "moment-timezone": "0.5.9",
     "yuidoc-ember-theme": "^1.2.1"
   },
   "keywords": [
@@ -86,7 +86,7 @@
     "ember-validators": "0.1.2",
     "ember-require-module": "^0.1.1",
     "ember-string-ishtmlsafe-polyfill": "1.0.1",
-    "exists-sync": "0.0.4",
+    "exists-sync": "0.0.3",
     "walk-sync": "^0.3.1"
   },
   "ember-addon": {


### PR DESCRIPTION
Let's say I have async email validation which will fire every keydown. In that case I want to debounce it every several milliseconds. I would assume that debounce will abort all promises before any new debounced function will start. Unfortunately it's not the case. In Ember CP Validations deboucing works more like deferring the validation because it never cancels previous async operation.