### PR TITLE
[BUGFIX] Debounce context not properly set

### DIFF
--- a/addon/validations/factory.js
+++ b/addon/validations/factory.js
@@ -473,7 +473,7 @@ function generateValidationResultsFor(attribute, model, validators, validate, op
 
       // Return a promise and pass the resolve method to the debounce handler
       value = new Promise((resolve) => {
-        let t = run.debounce(validator, resolve, debounce, false);
+        let t = run.debounce(validator, resolveDebounce, resolve, debounce);
 
         if (!opts.disableDebounceCache) {
           cache[guidFor(validator)] = t;
@@ -745,6 +745,18 @@ function lookupValidator(owner, type) {
   }
 
   return validatorClass;
+}
+
+/**
+ * Call the passed resolve method. This is needed as run.debounce expects a
+ * static method to work properly.
+ *
+ * @method resolveDebounce
+ * @private
+ * @param  {Function} resolve
+ */
+function resolveDebounce(resolve)  {
+  resolve();
 }
 
 /**

--- a/tests/integration/validations/factory-general-test.js
+++ b/tests/integration/validations/factory-general-test.js
@@ -339,6 +339,33 @@ test('debounced validations', function(assert) {
   }, 500);
 });
 
+test('debounced validator should only be called once', function(assert) {
+  let count = 0;
+
+  let done = assert.async();
+  let Validations = buildValidations({
+    firstName: validator(() => count++, {
+      debounce: 500
+    })
+  });
+
+  let object = setupObject(this, Ember.Object.extend(Validations));
+
+  object.set('firstName', 'O');
+  object.get('validations.attrs.firstName.isValid');
+
+  object.set('firstName', 'Off');
+  object.get('validations.attrs.firstName.isValid');
+
+  object.set('firstName', 'Offir');
+  object.get('validations.attrs.firstName.isValid');
+
+  run.later(() => {
+    assert.equal(count, 1);
+    done();
+  }, 500);
+});
+
 test('debounced validations should cleanup on object destroy', function(assert) {
   let done = assert.async();
   let initSetup = true;


### PR DESCRIPTION
Changes proposed:

 - Create a static `resolveDebounce` method to pass run.debounce

Tasks:

- [x] Added test case(s)
- [x] Updated documentation
