### PR TITLE
[BUGFIX] Performance Improvements

### DIFF
--- a/addon/-private/internal-result-object.js
+++ b/addon/-private/internal-result-object.js
@@ -13,7 +13,8 @@ const {
   isNone,
   computed,
   canInvoke,
-  makeArray
+  makeArray,
+  defineProperty
 } = Ember;
 
 const {
@@ -36,6 +37,8 @@ export default Ember.Object.extend({
 
   init() {
     this._super(...arguments);
+
+    defineProperty(this, 'attrValue', computed.readOnly(`model.${get(this, 'attribute')}`));
 
     if (this.get('isAsync')) {
       this._handlePromise();

--- a/addon/-private/options.js
+++ b/addon/-private/options.js
@@ -1,0 +1,51 @@
+import Ember from 'ember';
+import { isDescriptor } from 'ember-cp-validations/utils/utils';
+
+const {
+  get,
+  set,
+  defineProperty
+} = Ember;
+
+const Options = Ember.Object.extend({
+  model: null,
+  attribute: null,
+
+  // Private
+  __options__: null,
+
+  init() {
+    this._super(...arguments);
+
+    let options = this.get('__options__');
+
+    Object.keys(options).forEach((key) => {
+      let value = options[key];
+
+      if (isDescriptor(value)) {
+        defineProperty(this, key, value);
+      } else {
+        set(this, key, value);
+      }
+    });
+  },
+
+  copy(deep) {
+    let options = this.get('__options__');
+
+    if (deep) {
+      return Options.create({
+        model: get(this, 'model'),
+        attribute: get(this, 'attribute'),
+        __options__: options
+      });
+    }
+
+    return Ember.Object.create(Object.keys(options).reduce((obj, o) => {
+      obj[o] = get(this, o);
+      return obj;
+    }, {}));
+  }
+});
+
+export default Options;

--- a/addon/-private/result.js
+++ b/addon/-private/result.js
@@ -159,9 +159,7 @@ const Result = Ember.Object.extend({
    * @type {Result}
    */
   _validations: computed('model', 'attribute', '_promise', '_validator', function() {
-    return InternalResultObject.extend({
-      attrValue: computed.readOnly(`model.${get(this, 'attribute')}`)
-    }).create(getProperties(this, ['model', 'attribute', '_promise', '_validator']));
+    return InternalResultObject.create(getProperties(this, ['model', 'attribute', '_promise', '_validator']));
   }),
 
   init() {

--- a/addon/utils/utils.js
+++ b/addon/utils/utils.js
@@ -51,8 +51,12 @@ export function isEmberObject(o) {
   return !!(o && o instanceof Ember.Object);
 }
 
-export default function isObject(o) {
+export function isObject(o) {
   return typeOf(o) === 'object' || typeOf(o) === 'instance';
+}
+
+export function isDescriptor(o) {
+  return o && typeof o === 'object' && o.isDescriptor;
 }
 
 export function isValidatable(value) {

--- a/addon/validations/factory.js
+++ b/addon/validations/factory.js
@@ -11,7 +11,7 @@ import ResultCollection from './result-collection';
 import BaseValidator from '../validators/base';
 import cycleBreaker from '../utils/cycle-breaker';
 import shouldCallSuper from '../utils/should-call-super';
-import { isDsModel, isValidatable, isPromise, mergeOptions } from '../utils/utils';
+import { isDsModel, isValidatable, isPromise, isDescriptor, mergeOptions } from '../utils/utils';
 
 const {
   get,
@@ -611,7 +611,7 @@ function extractOptionsDependentKeys(options) {
     return Object.keys(options).reduce((arr, key) => {
       let option = options[key];
 
-      if (option && typeof option === 'object' && option.isDescriptor) {
+      if (isDescriptor(option)) {
         return arr.concat(option._dependentKeys || []);
       }
 

--- a/addon/validators/base.js
+++ b/addon/validators/base.js
@@ -5,6 +5,7 @@
 
 import Ember from 'ember';
 import Messages from 'ember-cp-validations/validators/messages';
+import Options from 'ember-cp-validations/-private/options';
 import { unwrapString, getValidatableValue, mergeOptions } from 'ember-cp-validations/utils/utils';
 
 const {
@@ -12,41 +13,8 @@ const {
   set,
   isNone,
   computed,
-  getOwner,
-  defineProperty
+  getOwner
 } = Ember;
-
-const Options = Ember.Object.extend({
-  model: null,
-  attribute: null,
-
-  // Private
-  __options__: null,
-
-  init() {
-    this._super(...arguments);
-
-    let options = this.get('__options__');
-
-    Object.keys(options).forEach((key) => {
-      let value = options[key];
-      if (value && typeof value === 'object' && value.isDescriptor) {
-        defineProperty(this, key, value);
-      } else {
-        set(this, key, value);
-      }
-    });
-  },
-
-  copy() {
-    let options = this.get('__options__');
-
-    return Ember.Object.create(Object.keys(options).reduce((obj, o) => {
-      obj[o] = get(this, o);
-      return obj;
-    }, {}));
-  }
-});
 
 /**
  * @class Base
@@ -147,24 +115,6 @@ const Base = Ember.Object.extend({
     // there is no need for it to be passed around
     this.value = builtOptions.value || this.value;
     delete builtOptions.value;
-
-    // let OptionsClass = Ember.Object.extend(builtOptions, {
-    //   model: computed(() => get(this, 'model')).readOnly(),
-    //   attribute: computed(() => get(this, 'attribute')).readOnly(),
-    //
-    //   copy(deep) {
-    //     if (deep) {
-    //       return OptionsClass.create();
-    //     }
-    //
-    //     return Ember.Object.create(Object.keys(builtOptions).reduce((obj, o) => {
-    //       obj[o] = get(this, o);
-    //       return obj;
-    //     }, {}));
-    //   }
-    // });
-    //
-    // return OptionsClass.create();
 
     return Options.create({
       model: get(this, 'model'),

--- a/tests/integration/validations/factory-general-test.js
+++ b/tests/integration/validations/factory-general-test.js
@@ -1050,3 +1050,55 @@ test('volatile validations should not recompute', function(assert) {
   assert.equal(obj.get('isInvalidGlobal'), true, 'isInvalidGlobal was expected to be TRUE');
   assert.equal(obj.get('validations.attrs.firstName.isValid'), true, 'isValid was expected to be TRUE');
 });
+
+test('load test', function(assert) {
+  this.register('validator:presence', PresenceValidator);
+
+  let Validations = buildValidations({
+    a: validator('presence', true),
+    b: validator('presence', true),
+    c: validator('presence', true),
+    d: validator('presence', true),
+    e: validator('presence', true)
+  });
+
+  let Klass = Ember.Object.extend(Validations, {
+    a: null,
+    b: null,
+    c: null,
+    d: null,
+    e: null
+  });
+
+  let items = Ember.A([]);
+  for (let i = 0; i < 50; i++) {
+    let obj = setupObject(this, Klass, {
+      a: i,
+      b: i,
+      c: i,
+      d: i,
+      e: i
+    });
+    items.push(obj);
+  }
+
+  console.time('init');
+  items.mapBy('validations.isValid');
+  console.timeEnd('init');
+
+  items.forEach((item, i) => {
+    item.setProperties({
+      a: i + 1000,
+      b: i + 1000,
+      c: i + 1000,
+      d: i + 1000,
+      e: i + 1000
+    });
+  });
+
+  console.time('after set');
+  Ember.A(items).mapBy('validations.isValid');
+  console.timeEnd('after set');
+
+  assert.ok(true);
+});


### PR DESCRIPTION
Resolves #381.

Changes proposed:

 - Use `defineProperty` instead of creating classes via `Ember.Object.extend`

Finds:

- Initially when I ran the test case provided in #381 by @jakesjews, I got a resulting time of ~550ms. With the added changes, I now see around a 150ms to 200ms decrease in time (sometimes more).
- After a bunch of time debugging, it looks like using `extend` to create new classes take a lot longer than actually using `defineProperty` on init. 

cc @stefanpenner @rwjblue have you guys noticed this sort of thing in the past? I mean... it makes sense but from past experience, `defineProperty` is a pretty heavy hitter in terms of performance. 

Tasks:

- [ ] Added test case(s)
- [ ] Updated documentation
