### PR TITLE
[BUGFIX] Replace private and deprecated `_lookupFactory` with public & performant `factoryFor`

### DIFF
--- a/addon/-private/factory-for.js
+++ b/addon/-private/factory-for.js
@@ -1,0 +1,14 @@
+/**
+  Utility to use `ApplicationInstance#factoryFor` if available (2.12+) and
+  fallback to private `_lookupFactory` otherwise
+*/
+export default function factoryFor(owner, type) {
+  let factory;
+  if (owner.factoryFor) {
+    let maybeFactory = owner.factoryFor(type);
+    factory = maybeFactory && maybeFactory.class;
+  } else {
+    factory = owner._lookupFactory(type);
+  }
+  return factory;
+}

--- a/addon/validations/factory.js
+++ b/addon/validations/factory.js
@@ -7,6 +7,7 @@ import Ember from 'ember';
 import flatten from '../utils/flatten';
 import assign from '../utils/assign';
 import ValidationResult from '../-private/result';
+import factoryFor from '../-private/factory-for';
 import ResultCollection from './result-collection';
 import BaseValidator from '../validators/base';
 import cycleBreaker from '../utils/cycle-breaker';
@@ -738,7 +739,7 @@ function createValidatorsFor(attribute, model) {
  * @return {Class} Validator class or undefined if not found
  */
 function lookupValidator(owner, type) {
-  let validatorClass = owner._lookupFactory(`validator:${type}`);
+  let validatorClass = factoryFor(owner, `validator:${type}`);
 
   if (isNone(validatorClass)) {
     throw new Error(`[ember-cp-validations] Validator not found of type: ${type}.`);

--- a/addon/validators/base.js
+++ b/addon/validators/base.js
@@ -6,6 +6,7 @@
 import Ember from 'ember';
 import Messages from 'ember-cp-validations/validators/messages';
 import Options from 'ember-cp-validations/-private/options';
+import factoryFor from '../-private/factory-for';
 import { unwrapString, getValidatableValue, mergeOptions } from 'ember-cp-validations/utils/utils';
 
 const {
@@ -88,7 +89,7 @@ const Base = Ember.Object.extend({
 
     if (!isNone(owner)) {
       // Since default error messages are stored in app/validators/messages, we have to look it up via the owner
-      errorMessages = owner._lookupFactory('validator:messages');
+      errorMessages = factoryFor(owner, 'validator:messages');
     }
 
     // If for some reason, we can't find the messages object (i.e. unit tests), use default


### PR DESCRIPTION
No API surface has changed. `_factoryFor` will be removed in 2.13.