### PR TITLE
[DOCS] Add note on testing and container access to "Basic" documentation

### DIFF
--- a/addon/index.js
+++ b/addon/index.js
@@ -92,8 +92,6 @@ import Validator from './validations/validator';
  * });
  * ```
  *
- * To lookup validators, container access is required which can cause an issue with `Ember.Object` creation if the object is statically imported. The current fix for this is as follows.
- *
  * ```javascript
  * // models/user.js
  *
@@ -101,6 +99,11 @@ import Validator from './validations/validator';
  *   username: null
  * });
  * ```
+ *
+ * ## A Note on Testing & Object Containers
+ *
+ * To lookup validators, container access is required, which can cause an issue with `Ember.Object` creation
+ * if the object is statically imported. The current fix for this is as follows.
  *
  * **Ember < 2.3.0**
  *
@@ -131,6 +134,16 @@ import Validator from './validations/validator';
  *      { username: 'John' }
  *     );
  *   }
+ * });
+ * ```
+ *
+ * This also has ramifications for Ember Data model tests. When using [Ember QUnit's `moduleForModel`](https://github.com/emberjs/ember-qunit#ember-data-tests)
+ * (or [Ember Mocha's `setupModelTest`](https://github.com/emberjs/ember-mocha#setup-model-tests)), you will need to specify all validators
+ * that your model depends on:
+ *
+ * ```javascript
+ * moduleForModel('foo', 'Unit | Model | model', {
+ *   needs: ['validator:presence']
  * });
  * ```
  *


### PR DESCRIPTION
This addresses part of #193 by adding a note on container access to the "Basic" section of the docs. 

Hopefully this helps any developers (myself included) who might be prone to encounter the issue noted in #191 😄.