### PR TITLE
Upgrading ember-string-ishtmlsafe-polyfill

### DIFF
--- a/addon/utils/utils.js
+++ b/addon/utils/utils.js
@@ -4,7 +4,6 @@
  */
 
 import Ember from 'ember';
-import isHTMLSafe from 'ember-string-ishtmlsafe-polyfill';
 import requireModule from 'ember-require-module';
 
 const DS = requireModule('ember-data');
@@ -16,6 +15,8 @@ const {
   canInvoke,
   A: emberArray
 } = Ember;
+
+const { isHTMLSafe } = Ember.String;
 
 const assign = Ember.assign || Ember.merge;
 

--- a/package.json
+++ b/package.json
@@ -83,7 +83,7 @@
     "ember-cli-version-checker": "^1.2.0",
     "ember-getowner-polyfill": "^1.2.0",
     "ember-require-module": "^0.1.1",
-    "ember-string-ishtmlsafe-polyfill": "1.0.1",
+    "ember-string-ishtmlsafe-polyfill": "^1.1.0",
     "ember-validators": "0.2.0",
     "exists-sync": "0.0.4",
     "walk-sync": "^0.3.1"


### PR DESCRIPTION
👋 -- We're updating [ember-string-ishtmlsafe-polyfill](https://github.com/workmanw/ember-string-ishtmlsafe-polyfill) to be a "native polyfill". Following the pattern provided by [ember-assign-polyfill](https://github.com/shipshapecode/ember-assign-polyfill) and [ember-getowner-polyfill](https://github.com/rwjblue/ember-getowner-polyfill).

Note: This is part of an effort to get all users of the polyfill updated.. workmanw/ember-string-ishtmlsafe-polyfill#5
