### PR TITLE
[FEATURE] Upgrade Ember Validators

### DIFF
--- a/addon/-private/ember-validator.js
+++ b/addon/-private/ember-validator.js
@@ -6,7 +6,7 @@ export default Base.extend({
     let result = _validate(this.get('_evType'), ...arguments);
 
     if (result && typeof result === 'object') {
-      return this.createErrorMessage(result.type, result.value, result.context);
+      return result.message ? result.message : this.createErrorMessage(result.type, result.value, result.context);
     }
 
     return result;

--- a/addon/validators/format.js
+++ b/addon/validators/format.js
@@ -3,14 +3,8 @@
  * Copyrights licensed under the New BSD License. See the accompanying LICENSE file for terms.
  */
 
-import Ember from 'ember';
 import EmberValidator from 'ember-cp-validations/-private/ember-validator';
 import { regularExpressions } from 'ember-validators/format';
-
-const {
-  get,
-  isNone
-} = Ember;
 
 /**
  *  <i class="fa fa-hand-o-right" aria-hidden="true"></i> [See All Options](#method_validate)
@@ -54,25 +48,5 @@ const {
  */
 export default EmberValidator.extend({
   _evType: 'format',
-  regularExpressions,
-
-  /**
-   * Normalized options passed in by applying the desired regex or using the one declared
-   *
-   * @method buildOptions
-   * @param  {Object}     options
-   * @param  {Object}     defaultOptions
-   * @param  {Object}     globalOptions
-   * @return {Object}
-   */
-  buildOptions(options = {}, defaultOptions = {}, globalOptions = {}) {
-    let regularExpressions = get(this, 'regularExpressions');
-    let { regex, type } = options;
-
-    if (type && !isNone(regularExpressions[type]) && isNone(regex)) {
-      options.regex = regularExpressions[type];
-    }
-
-    return this._super(options, defaultOptions, globalOptions);
-  }
+  regularExpressions
 });

--- a/addon/validators/length.js
+++ b/addon/validators/length.js
@@ -3,13 +3,7 @@
  * Copyrights licensed under the New BSD License. See the accompanying LICENSE file for terms.
  */
 
-import Ember from 'ember';
 import EmberValidator from 'ember-cp-validations/-private/ember-validator';
-
-const {
-  get,
-  isNone
-} = Ember;
 
 /**
  *  <i class="fa fa-hand-o-right" aria-hidden="true"></i> [See All Options](#method_validate)
@@ -33,20 +27,5 @@ const {
  *  @extends Base
  */
 export default EmberValidator.extend({
-  _evType: 'length',
-
-  /**
-   * Default allowNone to true
-   *
-   * @method buildOptions
-   * @param  {Object}     options
-   * @param  {Object}     defaultOptions
-   * @param  {Object}     globalOptions
-   * @return {Object}
-   */
-  buildOptions(options = {}, defaultOptions = {}, globalOptions = {}) {
-    options.allowNone = isNone(get(options, 'allowNone')) ? true : get(options, 'allowNone');
-
-    return this._super(options, defaultOptions, globalOptions);
-  }
+  _evType: 'length'
 });

--- a/package.json
+++ b/package.json
@@ -84,7 +84,7 @@
     "ember-getowner-polyfill": "^1.2.0",
     "ember-require-module": "^0.1.1",
     "ember-string-ishtmlsafe-polyfill": "^1.1.0",
-    "ember-validators": "0.2.0",
+    "ember-validators": "1.0.1",
     "exists-sync": "0.0.4",
     "walk-sync": "^0.3.1"
   },

--- a/tests/integration/validations/factory-general-test.js
+++ b/tests/integration/validations/factory-general-test.js
@@ -268,10 +268,9 @@ test('global options', function(assert) {
   assert.ok(object.get('validations.attrs.firstName.isInvalid'));
 
   let v = object.get('validations._validators.firstName.0');
-  assert.deepEqual(v.get('options').getProperties(['message', 'description', 'allowNone', 'min', 'max']), {
+  assert.deepEqual(v.get('options').getProperties(['message', 'description', 'min', 'max']), {
     message: 'Global error message',
     description: 'Test field',
-    allowNone: true,
     min: 1,
     max: 5
   });

--- a/tests/unit/validators/format-test.js
+++ b/tests/unit/validators/format-test.js
@@ -17,16 +17,6 @@ moduleFor('validator:format', 'Unit | Validator | format', {
   }
 });
 
-test('buildOptions', function(assert) {
-  assert.expect(2);
-
-  options = { type: 'email' };
-  builtOptions = validator.buildOptions(options, {}).copy();
-
-  assert.equal(builtOptions.get('type'), 'email');
-  assert.ok(builtOptions.get('regex'));
-});
-
 test('no options', function(assert) {
   assert.expect(1);
 


### PR DESCRIPTION
- Confirmation
  - allowBlank
- Format
  - inverse
- Length
  - Default allowNone to true
  - useBetweenMessage (If min and max are set, use the `between` error message type
- Number
  - allowNone (defaulted to true)
  - multipleOf