### PR TITLE
Documentation - Updated typo on example of validations

### DIFF
--- a/addon/index.js
+++ b/addon/index.js
@@ -266,7 +266,7 @@ import Validator from './validations/validator';
  * const Validations = buildValidations({
  *   'acceptTerms': validator('inclusion', { in: [ true ] }),
  *   'user.firstName': validator('presence', true),
- *   'user.lasName': validator('presence', true),
+ *   'user.lastName': validator('presence', true),
  *   'user.account.number': validator('number')
  * });
  *


### PR DESCRIPTION
The example on Ember.Component had `user.lasName` validation field instead of correct `user.lastName`

Just documentation change