### PR TITLE
Attempt to fix the test suite

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,13 +15,10 @@ addons:
 
 env:
   - EMBER_TRY_SCENARIO=default
-  - EMBER_TRY_SCENARIO=ember-1.11
-  - EMBER_TRY_SCENARIO=ember-1.12
   - EMBER_TRY_SCENARIO=ember-1.13
-  - EMBER_TRY_SCENARIO=ember-2.0
   - EMBER_TRY_SCENARIO=ember-lts-2.4
   - EMBER_TRY_SCENARIO=ember-lts-2.8
-  - EMBER_TRY_SCENARIO=ember-2.10
+  - EMBER_TRY_SCENARIO=ember-2.12
   - EMBER_TRY_SCENARIO=ember-release
   - EMBER_TRY_SCENARIO=ember-beta
   - EMBER_TRY_SCENARIO=ember-canary

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,6 @@ env:
   - EMBER_TRY_SCENARIO=ember-1.12
   - EMBER_TRY_SCENARIO=ember-1.13
   - EMBER_TRY_SCENARIO=ember-2.0
-  - EMBER_TRY_SCENARIO=ember-2.3
   - EMBER_TRY_SCENARIO=ember-lts-2.4
   - EMBER_TRY_SCENARIO=ember-lts-2.8
   - EMBER_TRY_SCENARIO=ember-2.10

--- a/config/ember-try.js
+++ b/config/ember-try.js
@@ -11,49 +11,6 @@ module.exports = {
       dependencies: {}
     }
   }, {
-    name: 'ember-1.11',
-    bower: {
-      dependencies: {
-        'ember': '~1.11.0',
-        'ember-cli-shims': '0.0.6',
-        'ember-data': '~1.13.0'
-      },
-      resolutions: {
-        'ember': '~1.11.0',
-        'ember-cli-shims': '0.0.6',
-        'ember-data': '~1.13.0'
-      }
-    },
-    npm: {
-      dependencies: {
-        'ember-get-helper': '^1.0.4'
-      },
-      devDependencies: {
-        'ember-cli-shims': null,
-        'ember-data': '~1.13.0',
-        'ember-source': null
-      }
-    }
-  }, {
-    name: 'ember-1.12',
-    bower: {
-      dependencies: {
-        'ember': '~1.12.0',
-        'ember-data': '~1.13.0',
-        'ember-cli-shims': '0.0.6'
-      }
-    },
-    npm: {
-      dependencies: {
-        'ember-get-helper': '^1.0.4'
-      },
-      devDependencies: {
-        'ember-cli-shims': null,
-        'ember-data': '~1.13.0',
-        'ember-source': null
-      }
-    }
-  }, {
     name: 'ember-1.13',
     bower: {
       dependencies: {
@@ -69,22 +26,6 @@ module.exports = {
       devDependencies: {
         'ember-cli-shims': null,
         'ember-data': '~1.13.0',
-        'ember-source': null
-      }
-    }
-  }, {
-    name: 'ember-2.0',
-    bower: {
-      dependencies: {
-        'ember': '~2.0.0',
-        'ember-data': '~2.0.0',
-        'ember-cli-shims': '0.0.6'
-      }
-    },
-    npm: {
-      devDependencies: {
-        'ember-cli-shims': null,
-        'ember-data': '~2.0.0',
         'ember-source': null
       }
     }
@@ -109,15 +50,15 @@ module.exports = {
       }
     }
   }, {
-    name: 'ember-2.10',
+    name: 'ember-2.12',
     bower: {
       dependencies: {
-        'ember': '~2.10.0'
+        'ember': '~2.12.0'
       }
     },
     npm: {
       dependencies: {
-        'ember-data': '~2.10.0'
+        'ember-data': '~2.12.0'
       }
     }
   }, {

--- a/config/ember-try.js
+++ b/config/ember-try.js
@@ -125,11 +125,15 @@ module.exports = {
     bower: {
       dependencies: {
         'ember': 'components/ember#release',
-        'ember-data': 'components/ember-data#release'
+        'ember-data': null
       },
       resolutions: {
-        'ember': 'release',
-        'ember-data': 'release'
+        'ember': 'release'
+      }
+    },
+    npm: {
+      dependencies: {
+        'ember-data': '~2.13.0'
       }
     }
   }, {

--- a/config/ember-try.js
+++ b/config/ember-try.js
@@ -15,13 +15,23 @@ module.exports = {
     bower: {
       dependencies: {
         'ember': '~1.11.0',
-        'ember-data': '~1.13.0',
-        'ember-cli-shims': '0.0.6'
+        'ember-cli-shims': '0.0.6',
+        'ember-data': '~1.13.0'
+      },
+      resolutions: {
+        'ember': '~1.11.0',
+        'ember-cli-shims': '0.0.6',
+        'ember-data': '~1.13.0'
       }
     },
     npm: {
       dependencies: {
         'ember-get-helper': '^1.0.4'
+      },
+      devDependencies: {
+        'ember-cli-shims': null,
+        'ember-data': '~1.13.0',
+        'ember-source': null
       }
     }
   }, {
@@ -36,6 +46,11 @@ module.exports = {
     npm: {
       dependencies: {
         'ember-get-helper': '^1.0.4'
+      },
+      devDependencies: {
+        'ember-cli-shims': null,
+        'ember-data': '~1.13.0',
+        'ember-source': null
       }
     }
   }, {
@@ -50,6 +65,11 @@ module.exports = {
     npm: {
       dependencies: {
         'ember-get-helper': '^1.0.4'
+      },
+      devDependencies: {
+        'ember-cli-shims': null,
+        'ember-data': '~1.13.0',
+        'ember-source': null
       }
     }
   }, {
@@ -60,13 +80,12 @@ module.exports = {
         'ember-data': '~2.0.0',
         'ember-cli-shims': '0.0.6'
       }
-    }
-  }, {
-    name: 'ember-2.3',
-    bower: {
-      dependencies: {
-        'ember': '~2.3.0',
-        'ember-data': '~2.3.0'
+    },
+    npm: {
+      devDependencies: {
+        'ember-cli-shims': null,
+        'ember-data': '~2.0.0',
+        'ember-source': null
       }
     }
   }, {


### PR DESCRIPTION
I'm not exactly sure what changed to make the test suite so unhappy, but in general ember-try seemed to be having problems installing ember data correctly so I updated a bunch of the failing scenarios to get them to work.

Of particular note:
 * It might make sense to remove some of the older scenarios at some point
 * I could not get the Ember 2.3 scenario working so I removed it.  Let me know if you feel strongly about keeping it and I can try again.
* The ember-release scenario was breaking because it couldn't run with ember data 2.14.  I think that is related to [this](https://github.com/emberjs/data/issues/5118) ember data issue so I made that scenario run with ember data 2.13 for now.