### PR TITLE
Adding Example of validator usage in component

### DIFF
--- a/addon/index.js
+++ b/addon/index.js
@@ -88,7 +88,13 @@ import Validator from './validations/validator';
  * });
  *
  * export default Ember.Component.extend(Validations, {
- *   bar: null
+ *   bar: null,
+ *   barStatus: Ember.computed('bar',function(){
+ *      if(this.get('validations.attrs.bar.isValid')){
+ *          return 'The Bar is Open';
+ *      }
+ *      return 'The Bar is Closed';
+ *   })
  * });
  * ```
  *


### PR DESCRIPTION
Adding a basic computed property to the object example that demonstrates how to get validation of non-model property via js.

Resolves # . 

I was looking at documentation in Usage/Basic and could not find an example of how to access a component property's validation. Found example in Validations/Accessing Validations. 

Changes proposed:

 - Adding Example of getting validation of a property in component to the existing documentation. 

Tasks:

- [x] Added test case(s) - _not applicable due to it just being a documentation update_
- [X] Updated documentation
