### PR TITLE
Validator Composability

### DIFF
--- a/addon/index.js
+++ b/addon/index.js
@@ -109,7 +109,7 @@ import Validator from './validations/validator';
  *
  * export default Ember.Route.extend({
  *   model() {
- *     var container = this.get('container');
+ *     const container = this.get('container');
  *     return User.create({ username: 'John', container })
  *   }
  * });

--- a/addon/utils/lookup-validator.js
+++ b/addon/utils/lookup-validator.js
@@ -1,0 +1,25 @@
+/**
+ * Lookup a validator of a specific type on the owner
+ *
+ * @param  {Ember.Owner} owner
+ * @param  {String} type
+ * @throws {Error} Validator not found
+ * @return {Class} Validator class
+ */
+export default function lookupValidator(owner, type) {
+  if (!owner) {
+    throw new Error(
+      `[ember-cp-validations] \`lookupValidator\` requires owner/container access.`
+    );
+  }
+
+  const validatorClass = owner.factoryFor(`validator:${type}`);
+
+  if (!validatorClass) {
+    throw new Error(
+      `[ember-cp-validations] Validator not found of type: ${type}.`
+    );
+  }
+
+  return validatorClass;
+}

--- a/addon/validations/factory.js
+++ b/addon/validations/factory.js
@@ -8,7 +8,6 @@ import { isEmpty, isNone } from '@ember/utils';
 import { getOwner } from '@ember/application';
 import EmberObject, { getWithDefault, computed, set, get } from '@ember/object';
 import { A as emberArray, makeArray, isArray } from '@ember/array';
-
 import Ember from 'ember';
 import deepSet from '../utils/deep-set';
 import ValidationResult from '../-private/result';
@@ -16,6 +15,7 @@ import ResultCollection from './result-collection';
 import BaseValidator from '../validators/base';
 import cycleBreaker from '../utils/cycle-breaker';
 import shouldCallSuper from '../utils/should-call-super';
+import lookupValidator from '../utils/lookup-validator';
 import { flatten } from '../utils/array';
 import {
   isDsModel,
@@ -773,28 +773,6 @@ function createValidatorsFor(attribute, model) {
   deepSet(validatorCache, attribute, validators);
 
   return validators;
-}
-
-/**
- * Lookup a validators of a specific type on the owner
- *
- * @method lookupValidator
- * @throws {Error} Validator not found
- * @private
- * @param  {Ember.Owner} owner
- * @param  {String} type
- * @return {Class} Validator class or undefined if not found
- */
-function lookupValidator(owner, type) {
-  let validatorClass = owner.factoryFor(`validator:${type}`);
-
-  if (isNone(validatorClass)) {
-    throw new Error(
-      `[ember-cp-validations] Validator not found of type: ${type}.`
-    );
-  }
-
-  return validatorClass;
 }
 
 /**

--- a/addon/validators/base.js
+++ b/addon/validators/base.js
@@ -246,11 +246,18 @@ const Base = EmberObject.extend({
 
   /**
    * Easily compose complicated validations by using this method to validate
-   * against pre-existing validators.
+   * against other validators.
    *
    * ```javascript
    * validate(value, options, ...args) {
    *   let result = this.test('presence', value, { presence: true }, ...args);
+   *
+   *   if (!result.isValid) {
+   *     return result.message;
+   *   }
+   *
+   *   // You can even test against your own custom validators
+   *   result = this.test('my-validator', value, { foo: 'bar' }, ...args);
    *
    *   if (!result.isValid) {
    *     return result.message;

--- a/addon/validators/base.js
+++ b/addon/validators/base.js
@@ -277,6 +277,8 @@ const Base = EmberObject.extend({
    * ```
    * @method test
    * @param  {String} type    The validator type (e.x. 'presence', 'length', etc.)
+   *                          The following types are unsupported:
+   *                            'alias', 'belongs-to', 'dependent', 'has-many'
    * @param  {...} args       The params to pass through to the validator
    * @return {Object}         The test result object which will contain `isValid`
    *                          and `message`. If the validator is async, then the

--- a/addon/validators/base.js
+++ b/addon/validators/base.js
@@ -81,7 +81,7 @@ const Base = EmberObject.extend({
   _type: null,
 
   /**
-   * Validators cache used back `validates`
+   * Validators cache used by `test` api
    * @property _testValidatorCache
    * @private
    * @type {Object}

--- a/blueprints/validator-test/qunit-files/tests/unit/validators/__name__-test.js
+++ b/blueprints/validator-test/qunit-files/tests/unit/validators/__name__-test.js
@@ -5,6 +5,6 @@ moduleFor('validator:<%= dasherizedModuleName %>', 'Unit | Validator | <%= dashe
 });
 
 test('it works', function(assert) {
-  var validator = this.subject();
+  const validator = this.subject();
   assert.ok(validator);
 });

--- a/package.json
+++ b/package.json
@@ -62,6 +62,8 @@
     "ember-export-application-global": "^2.0.0",
     "ember-font-awesome": "^3.0.5",
     "ember-load-initializers": "^1.0.0",
+    "ember-maybe-import-regenerator": "^0.1.6",
+    "ember-qunit-nice-errors": "^1.2.0",
     "ember-resolver": "^4.3.0",
     "ember-source": "~2.18.0",
     "ember-truth-helpers": "1.3.0",

--- a/tests/integration/validators/composable-test.js
+++ b/tests/integration/validators/composable-test.js
@@ -1,0 +1,225 @@
+import DefaultMessages from 'dummy/validators/messages';
+import LengthValidator from 'ember-cp-validations/validators/length';
+import PresenceValidator from 'ember-cp-validations/validators/presence';
+import BaseValidator from 'ember-cp-validations/validators/base';
+import EmberObject from '@ember/object';
+import setupObject from '../../helpers/setup-object';
+import { validator, buildValidations } from 'ember-cp-validations';
+import { moduleFor, test } from 'ember-qunit';
+import { Promise } from 'rsvp';
+
+const ComposedValidations = buildValidations({
+  value: validator('composed')
+});
+
+moduleFor('foo', 'Integration | Validators | Composable', {
+  integration: true,
+  beforeEach() {
+    this.register('validator:messages', DefaultMessages);
+  }
+});
+
+test('Composability - simple', function(assert) {
+  assert.expect(5);
+
+  this.register('validator:presence', PresenceValidator);
+  this.register(
+    'validator:composed',
+    BaseValidator.extend({
+      validate(value) {
+        return this.test('presence', value, { presence: true });
+      }
+    })
+  );
+
+  const obj = setupObject(this, EmberObject.extend(ComposedValidations), {
+    value: ''
+  });
+
+  assert.equal(obj.get('validations.isValid'), false);
+  assert.equal(obj.get('validations.isValidating'), false);
+  assert.equal(obj.get('validations.message'), "This field can't be blank");
+
+  obj.set('value', 'foo');
+
+  assert.equal(obj.get('validations.isValid'), true);
+  assert.equal(obj.get('validations.isValidating'), false);
+});
+
+test('Composability - multiple', function(assert) {
+  assert.expect(8);
+
+  this.register('validator:presence', PresenceValidator);
+  this.register('validator:length', LengthValidator);
+  this.register(
+    'validator:composed',
+    BaseValidator.extend({
+      validate(value) {
+        let result = this.test('presence', value, { presence: true });
+
+        if (!result.isValid) {
+          return result.message;
+        }
+
+        result = this.test('length', value, { max: 5 });
+
+        if (!result.isValid) {
+          return result.message;
+        }
+
+        return true;
+      }
+    })
+  );
+
+  const obj = setupObject(this, EmberObject.extend(ComposedValidations), {
+    value: ''
+  });
+
+  assert.equal(obj.get('validations.isValid'), false);
+  assert.equal(obj.get('validations.isValidating'), false);
+  assert.equal(obj.get('validations.message'), "This field can't be blank");
+
+  obj.set('value', 'foobar');
+
+  assert.equal(obj.get('validations.isValid'), false);
+  assert.equal(obj.get('validations.isValidating'), false);
+  assert.equal(
+    obj.get('validations.message'),
+    'This field is too long (maximum is 5 characters)'
+  );
+
+  obj.set('value', 'foo');
+
+  assert.equal(obj.get('validations.isValid'), true);
+  assert.equal(obj.get('validations.isValidating'), false);
+});
+
+test('Composability - async', async function(assert) {
+  assert.expect(8);
+
+  this.register(
+    'validator:async-resolve',
+    BaseValidator.extend({
+      validate(value) {
+        return Promise.resolve(
+          value.includes('foo') ? true : 'Must include foo!'
+        );
+      }
+    })
+  );
+
+  this.register(
+    'validator:async-reject',
+    BaseValidator.extend({
+      validate(value) {
+        return Promise.reject(
+          value.includes('bar') ? true : 'Must include bar!'
+        );
+      }
+    })
+  );
+
+  this.register(
+    'validator:composed',
+    BaseValidator.extend({
+      async validate(value) {
+        let result = await this.test('async-resolve', value);
+
+        if (!result.isValid) {
+          return result.message;
+        }
+
+        result = await this.test('async-reject', value);
+
+        if (!result.isValid) {
+          return result.message;
+        }
+
+        return true;
+      }
+    })
+  );
+
+  const obj = setupObject(this, EmberObject.extend(ComposedValidations), {
+    value: ''
+  });
+
+  await obj.validate();
+
+  assert.equal(obj.get('validations.isValid'), false);
+  assert.equal(obj.get('validations.isValidating'), false);
+  assert.equal(obj.get('validations.message'), 'Must include foo!');
+
+  obj.set('value', 'foo');
+  await obj.validate();
+
+  assert.equal(obj.get('validations.isValid'), false);
+  assert.equal(obj.get('validations.isValidating'), false);
+  assert.equal(obj.get('validations.message'), 'Must include bar!');
+
+  obj.set('value', 'foobar');
+  await obj.validate();
+
+  assert.equal(obj.get('validations.isValid'), true);
+  assert.equal(obj.get('validations.isValidating'), false);
+});
+
+test('Composability - unsupported types', function(assert) {
+  const unsupportedTypes = ['alias', 'belongs-to', 'dependent', 'has-many'];
+
+  assert.expect(unsupportedTypes.length);
+
+  unsupportedTypes.forEach(type =>
+    this.register(`validator:${type}`, BaseValidator)
+  );
+
+  this.register(
+    'validator:composed',
+    BaseValidator.extend({
+      validate(type) {
+        this.test(type);
+      }
+    })
+  );
+
+  const obj = setupObject(this, EmberObject.extend(ComposedValidations), {
+    value: ''
+  });
+
+  unsupportedTypes.forEach(type => {
+    obj.set('value', type);
+    assert.throws(() => obj.validateSync(), new RegExp(type));
+  });
+});
+
+test('Validators get cached', function(assert) {
+  assert.expect(3);
+
+  this.register('validator:presence', PresenceValidator);
+  this.register(
+    'validator:composed',
+    BaseValidator.extend({
+      validate(value) {
+        const cache = this.get('_testValidatorCache');
+
+        assert.notOk(cache.presence);
+
+        this.test('presence', value, { presence: true });
+
+        const presenceValidator = cache.presence;
+        assert.ok(cache.presence);
+
+        this.test('presence', value, { presence: false });
+
+        assert.equal(presenceValidator, cache.presence);
+      }
+    })
+  );
+
+  const obj = setupObject(this, EmberObject.extend(ComposedValidations), {
+    value: ''
+  });
+
+  obj.validateSync();
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -348,6 +348,10 @@ ast-traverse@~0.1.1:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/ast-traverse/-/ast-traverse-0.1.1.tgz#69cf2b8386f19dcda1bb1e05d68fe359d8897de6"
 
+ast-types@0.10.2:
+  version "0.10.2"
+  resolved "https://registry.yarnpkg.com/ast-types/-/ast-types-0.10.2.tgz#aef76a04fde54634976fc94defaad1a67e2eadb0"
+
 ast-types@0.8.12:
   version "0.8.12"
   resolved "https://registry.yarnpkg.com/ast-types/-/ast-types-0.8.12.tgz#a0d90e4351bb887716c83fd637ebf818af4adfcc"
@@ -509,7 +513,7 @@ babel-core@^5.0.0:
     trim-right "^1.0.0"
     try-resolve "^1.0.0"
 
-babel-core@^6.14.0, babel-core@^6.24.1, babel-core@^6.26.0:
+babel-core@^6.10.4, babel-core@^6.14.0, babel-core@^6.24.1, babel-core@^6.26.0:
   version "6.26.0"
   resolved "https://registry.yarnpkg.com/babel-core/-/babel-core-6.26.0.tgz#af32f78b31a6fcef119c87b0fd8d9753f03a0bb8"
   dependencies:
@@ -2735,7 +2739,7 @@ ember-cli-babel@^5.1.3, ember-cli-babel@^5.1.5, ember-cli-babel@^5.1.6, ember-cl
     ember-cli-version-checker "^1.0.2"
     resolve "^1.1.2"
 
-ember-cli-babel@^6.0.0, ember-cli-babel@^6.10.0, ember-cli-babel@^6.6.0, ember-cli-babel@^6.8.1, ember-cli-babel@^6.8.2, ember-cli-babel@^6.9.0:
+ember-cli-babel@^6.0.0, ember-cli-babel@^6.0.0-beta.4, ember-cli-babel@^6.10.0, ember-cli-babel@^6.6.0, ember-cli-babel@^6.8.1, ember-cli-babel@^6.8.2, ember-cli-babel@^6.9.0:
   version "6.11.0"
   resolved "https://registry.yarnpkg.com/ember-cli-babel/-/ember-cli-babel-6.11.0.tgz#79cb184bac3c05bfe181ddc306bac100ab1f9493"
   dependencies:
@@ -3254,6 +3258,24 @@ ember-load-initializers@^1.0.0:
   dependencies:
     ember-cli-babel "^6.0.0-beta.7"
 
+ember-maybe-import-regenerator@^0.1.6:
+  version "0.1.6"
+  resolved "https://registry.yarnpkg.com/ember-maybe-import-regenerator/-/ember-maybe-import-regenerator-0.1.6.tgz#35d41828afa6d6a59bc0da3ce47f34c573d776ca"
+  dependencies:
+    broccoli-funnel "^1.0.1"
+    broccoli-merge-trees "^1.0.0"
+    ember-cli-babel "^6.0.0-beta.4"
+    regenerator-runtime "^0.9.5"
+
+ember-qunit-nice-errors@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/ember-qunit-nice-errors/-/ember-qunit-nice-errors-1.2.0.tgz#8db4468fbe761f42bec9adcddfd21efa31237267"
+  dependencies:
+    babel-core "^6.10.4"
+    broccoli-persistent-filter "^1.4.3"
+    ember-cli-babel "^6.6.0"
+    recast "^0.13.0"
+
 ember-qunit@^3.3.0:
   version "3.3.0"
   resolved "https://registry.yarnpkg.com/ember-qunit/-/ember-qunit-3.3.0.tgz#98c0c8d9473808fa7be48808989255cbfa70e760"
@@ -3628,7 +3650,7 @@ esprima@^3.1.3, esprima@~3.1.0:
   version "3.1.3"
   resolved "https://registry.yarnpkg.com/esprima/-/esprima-3.1.3.tgz#fdca51cee6133895e3c88d535ce49dbff62a4633"
 
-esprima@^4.0.0:
+esprima@^4.0.0, esprima@~4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/esprima/-/esprima-4.0.0.tgz#4499eddcd1110e0b218bacf2fa7f7f59f55ca804"
 
@@ -7307,6 +7329,15 @@ recast@^0.11.17, recast@^0.11.3:
     private "~0.1.5"
     source-map "~0.5.0"
 
+recast@^0.13.0:
+  version "0.13.1"
+  resolved "https://registry.yarnpkg.com/recast/-/recast-0.13.1.tgz#e838ac26c47599606413ff4fe83617552069921d"
+  dependencies:
+    ast-types "0.10.2"
+    esprima "~4.0.0"
+    private "~0.1.5"
+    source-map "~0.6.1"
+
 redent@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/redent/-/redent-1.0.0.tgz#cf916ab1fd5f1f16dfb20822dd6ec7f730c2afde"
@@ -7331,6 +7362,10 @@ regenerator-runtime@^0.10.5:
 regenerator-runtime@^0.11.0:
   version "0.11.1"
   resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz#be05ad7f9bf7d22e056f9726cee5017fbf19e2e9"
+
+regenerator-runtime@^0.9.5:
+  version "0.9.6"
+  resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.9.6.tgz#d33eb95d0d2001a4be39659707c51b0cb71ce029"
 
 regenerator-transform@^0.10.0:
   version "0.10.1"


### PR DESCRIPTION
Easily compose complicated validations by using this `this.test` to validate
against pre-existing validators.

```javascript
validate(value, options, ...args) {
  let result = this.test('presence', value, { presence: true }, ...args);

  if (!result.isValid) {
    return result.message;
  }

  result = this.test('number', value, { integer: true }, ...args);

  // You can easily override the error message by returning your own.
  if (!result.isValid) {
      return 'This value must be an integer!';
    }

  // Add custom logic...

  return true;
}
```

Tasks:

- [x] Added test case(s)
- [x] Updated documentation
