### PR TITLE
Update `ember-require-module` to v0.1.3 (v3.x)

### DIFF
--- a/package.json
+++ b/package.json
@@ -80,7 +80,7 @@
     "ember-cli-babel": "^6.6.0",
     "ember-cli-version-checker": "^2.0.0",
     "ember-getowner-polyfill": "^2.0.1",
-    "ember-require-module": "0.1.2",
+    "ember-require-module": "0.1.3",
     "ember-string-ishtmlsafe-polyfill": "^2.0.0",
     "ember-validators": "1.0.4",
     "exists-sync": "0.0.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3035,11 +3035,11 @@ ember-qunit@^2.1.3:
   dependencies:
     ember-test-helpers "^0.6.3"
 
-ember-require-module@0.1.2, ember-require-module@^0.1.2:
-  version "0.1.2"
-  resolved "https://registry.yarnpkg.com/ember-require-module/-/ember-require-module-0.1.2.tgz#fdffdcf86745d601009211c1b41907395a4d081e"
+ember-require-module@0.1.3, ember-require-module@^0.1.2:
+  version "0.1.3"
+  resolved "https://registry.yarnpkg.com/ember-require-module/-/ember-require-module-0.1.3.tgz#f82f60552142179152d28ec97ebd75d967cae1dc"
   dependencies:
-    ember-cli-babel "^5.1.7"
+    ember-cli-babel "^6.9.2"
 
 ember-resolver@^4.3.0:
   version "4.3.0"


### PR DESCRIPTION
This PR updates `ember-require-module` to get rid of Babel 5 deprecation warnings

Addresses https://github.com/offirgolan/ember-cp-validations/commit/92cbc833b6236e2339752d0e249f4c17be0b4b7d#commitcomment-28711518

/cc @offirgolan 
