### PR TITLE
updated installation instructions for ember-intl support

### DIFF
--- a/addon/index.js
+++ b/addon/index.js
@@ -284,10 +284,10 @@ import { hasValidations as validationDecorator } from './decorators/has-validati
  */
 
 /**
- * ### [__Ember-Intl__](https://github.com/jasonmit/ember-intl-cp-validations)
+ * ### [__Ember-Intl__](https://github.com/ember-intl/cp-validations)
  *
  *  ```bash
- *  ember install ember-intl-cp-validations
+ *  ember install @ember-intl/cp-validations
  *  ```
  *
  * ### [__Ember-I18n__](https://github.com/jasonmit/ember-i18n-cp-validations)


### PR DESCRIPTION
Resolves no issue. Was wondering when the outdated ember-cli-babel will finally be upgraded until I noticed that the package name seems to has been changed.

Changes proposed:

 - Updates the installation instructions to use @ember-intl/cp-validations instead of ember-intl-cp-validations

Tasks:

- [ ] Added test case(s)
- [x] Updated documentation