### PR TITLE
detect latest ember-mocha package as well

### DIFF
--- a/blueprints/validator-test/index.js
+++ b/blueprints/validator-test/index.js
@@ -9,7 +9,7 @@ module.exports = {
     const dependencies = this.project.dependencies();
     let type;
 
-    if ('ember-cli-mocha' in dependencies) {
+    if (('ember-mocha' in dependencies) || ('ember-cli-mocha' in dependencies)) {
       type = 'mocha';
     } else if ('ember-cli-qunit' in dependencies) {
       type = 'qunit';


### PR DESCRIPTION
Manually tested on our application using only ember-mocha and this
successfully generated the unit test.

Changes proposed:

 - detect ember-mocha first, then ember-cli-mocha

@Turbo87 can correct me if I am wrong here, but I think applications using mocha for testing will only need to include `ember-mocha` going forward.

