### PR TITLE
Remove NAME_KEY from addon/validations/factory.js

### DIFF
--- a/addon/validations/factory.js
+++ b/addon/validations/factory.js
@@ -98,7 +98,7 @@ export default function buildValidations(validations = {}, globalOptions = {}) {
 
   let Validations, validationMixinCount;
 
-  let ValidationsMixin = Ember.Mixin.create({
+  return Ember.Mixin.create({
     init() {
       this._super(...arguments);
 
@@ -140,11 +140,6 @@ export default function buildValidations(validations = {}, globalOptions = {}) {
       get(this, 'validations').destroy();
     }
   });
-
-  // Label mixin under a named scope for Ember Inspector
-  ValidationsMixin[Ember.NAME_KEY] = 'Validations';
-
-  return ValidationsMixin;
 }
 
 /**


### PR DESCRIPTION
Resolves #626 (but resolves it on the 3.x branch)

Changes proposed:
 - This removes NAME_KEY  on the 3.x branch. See commit: https://github.com/offirgolan/ember-cp-validations/commit/283fc0596b2ee8a44eaa87704a56f135a69dd4ae
 - This lets users use ember 3.12 and ember-cp-validations without using a beta.

Tasks:
[x] Ran tests--tests passed:
1..266
# tests 266
# pass  266
# skip  0
# fail  0

