### PR TITLE
Replace `getWithDefault` function 

### DIFF
--- a/addon/utils/get-with-default.js
+++ b/addon/utils/get-with-default.js
@@ -1,0 +1,10 @@
+import { get } from '@ember/object';
+
+export default function getWithDefault(obj, key, defaultValue) {
+  let result = get(obj, key);
+
+  if (result === undefined) {
+    result = defaultValue;
+  }
+  return result;
+}

--- a/addon/validations/factory.js
+++ b/addon/validations/factory.js
@@ -1,6 +1,6 @@
 import Mixin from '@ember/object/mixin';
 import { Promise } from 'rsvp';
-import EmberObject, { getWithDefault, computed, set, get } from '@ember/object';
+import EmberObject, { computed, set, get } from '@ember/object';
 import { A as emberArray, makeArray, isArray } from '@ember/array';
 import { readOnly } from '@ember/object/computed';
 import { assign } from '@ember/polyfills';
@@ -16,6 +16,7 @@ import cycleBreaker from '../utils/cycle-breaker';
 import shouldCallSuper from '../utils/should-call-super';
 import lookupValidator from '../utils/lookup-validator';
 import { flatten } from '../utils/array';
+import getWithDefault from '../utils/get-with-default';
 import {
   getDependentKeys,
   isDescriptor,

--- a/addon/validators/dependent.js
+++ b/addon/validators/dependent.js
@@ -1,8 +1,9 @@
-import { getProperties, getWithDefault, get } from '@ember/object';
+import { getProperties, get } from '@ember/object';
 import { assert } from '@ember/debug';
 import { isPresent, isEmpty, isNone } from '@ember/utils';
 import { isArray, A } from '@ember/array';
 import Base from 'ember-cp-validations/validators/base';
+import getWithDefault from '../utils/get-with-default';
 
 /**
  *  <i class="fa fa-hand-o-right" aria-hidden="true"></i> [See All Options](#method_validate)

--- a/tests/unit/utils/get-with-default-test.js
+++ b/tests/unit/utils/get-with-default-test.js
@@ -1,0 +1,25 @@
+import { module, test } from 'qunit';
+import getWithDefault from 'ember-cp-validations/utils/get-with-default';
+
+module('Unit | Utils | get with default', function() {
+  test('return the default value when value is undefined', function(assert) {
+    const undefinedObj = {
+      foo: undefined
+    };
+    const defaultValue = 'something';
+    let result = getWithDefault(undefinedObj, 'foo', defaultValue);
+
+    assert.equal(result, defaultValue);
+  });
+
+  test('return the correct value if defined', function(assert) {
+    const obj = {
+      yehuda: 'katz'
+    };
+
+    const defaultValue = 'something';
+    let result = getWithDefault(obj, 'yehuda', defaultValue);
+
+    assert.equal(result, 'katz');
+  });
+});


### PR DESCRIPTION
Resolves #680.
This PR aims to remove all usage of `getWithDefault` function into `ember-cp-validations`

Here's the link of the deprecation https://deprecations.emberjs.com/v3.x/#toc_ember-metal-get-with-default
Heavily inspired by [getWithDefautl function in Ember](https://github.com/emberjs/ember.js/blob/master/packages/@ember/-internals/metal/lib/property_get.ts#L180)

Changes proposed:

 - update to replace `getWithDefault` with `get` in `addon/validators/dependent.js`
 - update to replace `getWithDefault` with `get` in `addon/validations/factory.js`
 

I wanted to use the **Nullish coalescing operator** `??` but it's not available yet in this repo .. :/
