### PR TITLE
Bump node version and ember-validators from ^2.0.0 to ^3.0.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ language: node_js
 node_js:
   # we recommend testing addons with the same minimum supported node version as Ember CLI
   # so that your addon works for all apps
-  - '8'
+  - '10'
 
 sudo: false
 dist: trusty

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "test:all": "ember try:each"
   },
   "engines": {
-    "node": "8.* || >= 10.*"
+    "node": "10.* || >= 12"
   },
   "contributors": [
     {
@@ -99,7 +99,7 @@
   "dependencies": {
     "ember-cli-babel": "^7.1.2",
     "ember-require-module": "^0.3.0",
-    "ember-validators": "^2.0.0"
+    "ember-validators": "^3.0.1"
   },
   "ember-addon": {
     "configPath": "tests/dummy/config",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4894,10 +4894,10 @@ ember-try@^1.1.0:
     rsvp "^4.7.0"
     walk-sync "^1.1.3"
 
-ember-validators@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/ember-validators/-/ember-validators-2.0.0.tgz#4100e17feb9c3a6cf4072732010697bbd674f8cb"
-  integrity sha512-OhXGN2UbFQY+lhkWOdW347NZsIWGj/fpTJbOfNxjyMQW/c3fvPEIvrhlvWf1JwHGKQTJDHpMQJgA/Luq39GDgQ==
+ember-validators@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/ember-validators/-/ember-validators-3.0.1.tgz#9e0f7ed4ce6817aa05f7d46e95a0267c03f1f043"
+  integrity sha512-GbvvECDG9N7U+4LXxPWNgiSnGbOzgvGBIxtS4kw2uyEIy7kymtgszhpSnm8lGMKYnhCKBqFingh8qnVKlCi0lg==
   dependencies:
     ember-cli-babel "^6.9.2"
     ember-require-module "^0.3.0"


### PR DESCRIPTION
Part of #680 

`getWithDefault` has been replaced in dependency `ember-validators`: offirgolan/ember-validators/pull/77

So I had to bump the project node version also 🤔 
Let me know if I should pluck the node update into a separate PR